### PR TITLE
Use Redis increment to update counts

### DIFF
--- a/lib/split/alternative.rb
+++ b/lib/split/alternative.rb
@@ -18,12 +18,12 @@ module Split
 
     def increment_participation
       @participant_count +=1
-      self.save
+      Split.redis.hincrby "#{experiment_name}:#{name}", 'participant_count', 1
     end
 
     def increment_completion
       @completed_count +=1
-      self.save
+      Split.redis.hincrby "#{experiment_name}:#{name}", 'completed_count', 1
     end
 
     def control?

--- a/spec/alternative_spec.rb
+++ b/spec/alternative_spec.rb
@@ -40,6 +40,8 @@ describe Split::Alternative do
     old_participant_count = alternative.participant_count
     alternative.increment_participation
     alternative.participant_count.should eql(old_participant_count+1)
+
+    Split::Alternative.find('Basket', 'basket_text').participant_count.should eql(old_participant_count+1)
   end
 
   it "should increment completed count" do
@@ -49,6 +51,8 @@ describe Split::Alternative do
     old_completed_count = alternative.participant_count
     alternative.increment_completion
     alternative.completed_count.should eql(old_completed_count+1)
+
+    Split::Alternative.find('Basket', 'basket_text').completed_count.should eql(old_completed_count+1)
   end
 
   it "can be reset" do


### PR DESCRIPTION
Increment alternative participant and completion count using atomic Redis operations. Should fix concurrency issues when there are multiple Rails instances updating data simultaneously.
