### PR TITLE
Redis failover solution

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -2,10 +2,14 @@ module Split
   class Configuration
     attr_accessor :robot_regex
     attr_accessor :ignore_ip_addresses
+    attr_accessor :db_failover
+    attr_accessor :db_failover_on_db_error
 
     def initialize
       @robot_regex = /\b(Baidu|Gigabot|Googlebot|libwww-perl|lwp-trivial|msnbot|SiteUptime|Slurp|WordPress|ZIBB|ZyBorg)\b/i
       @ignore_ip_addresses = []
+      @db_failover = false
+      @db_failover_on_db_error = proc{|error|} # e.g. use Rails logger here
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -6,5 +6,7 @@ describe Split::Configuration do
 
     config.ignore_ip_addresses.should eql([])
     config.robot_regex.should eql(/\b(Baidu|Gigabot|Googlebot|libwww-perl|lwp-trivial|msnbot|SiteUptime|Slurp|WordPress|ZIBB|ZyBorg)\b/i)
+    config.db_failover.should be_false
+    config.db_failover_on_db_error.should be_a Proc
   end
 end


### PR DESCRIPTION
Due to the fact that redis has no autom. failover mechanism, it is now
possible to switch on 'db_failover' config option, so that 'ab_test' and
'finished' will not crash. 'ab_test' always delivers alternative A (the
first one) in that case. It's also possible to set a 'db_failover_on_db_error'
handler (proc) in the config, for example to log these errors via
Rails.logger.
