### PR TITLE
Bug fix for ab_test helper

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -6,7 +6,7 @@ module Split
         if experiment.winner
           ret = experiment.winner.name
         else
-          if forced_alternative = override(experiment.name, alternatives)
+          if forced_alternative = override(experiment.name, experiment.alternative_names)
             ret = forced_alternative
           else
             begin_experiment(experiment, experiment.control.name) if exclude_visitor?

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -50,6 +50,13 @@ describe Split::Helper do
       @params = {'link_color' => 'blue'}
       alternative = ab_test('link_color', 'blue', 'red')
       alternative.should eql('blue')
+      alternative = ab_test('link_color', 'blue' => 1, 'red' => 5)
+      alternative.should eql('blue')
+      @params = {'link_color' => 'red'}
+      alternative = ab_test('link_color', 'blue', 'red')
+      alternative.should eql('red')
+      alternative = ab_test('link_color', 'blue' => 5, 'red' => 1)
+      alternative.should eql('red')
     end
 
     it "should allow passing a block" do


### PR DESCRIPTION
It was not possible to override alternatives via params when using weighted alternatives with `ab_test` helper.
