### PR TITLE
Fix specifying weights for existing experiments

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -138,7 +138,7 @@ module Split
 
       if Split.redis.exists(name)
         if load_alternatives_for(name) == alts.map(&:name)
-          experiment = self.new(name, *load_alternatives_for(name))
+          experiment = self.new(name, *alternatives)
         else
           exp = self.new(name, *load_alternatives_for(name))
           exp.reset

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -184,4 +184,20 @@ describe Split::Experiment do
       lambda { Split::Experiment.find_or_create('link_enabled', true, false) }.should raise_error
     end
   end
+
+  describe 'specifying weights' do
+    it "should work for a new experiment" do
+      experiment = Split::Experiment.find_or_create('link_color', { 'blue' => 1, 'red' => 2 })
+
+      experiment.alternatives.map(&:weight).should == [1, 2]
+    end
+
+    it "should work for an existing experiment" do
+      experiment = Split::Experiment.find_or_create('link_color', 'blue', 'red')
+      experiment.save
+
+      same_experiment = Split::Experiment.find_or_create('link_color', { 'blue' => 1, 'red' => 2 })
+      same_experiment.alternatives.map(&:weight).should == [1, 2]
+    end
+  end
 end


### PR DESCRIPTION
Hi there,

I've run into an issue with split: when specifying weights for an existing experiment, the weights are simply ignored (i.e. all alternatives have weight 1). The problem is, that the alternatives for an existing experiment are loaded from redis, where only names and not weights are stored. The fix is very small, and I've included specs showing the bug.

Cheers,
Andreas
