### PR TITLE
Fix failing tests on Rubinius (issue #52)

### DIFF
--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -319,7 +319,7 @@ describe Split::Helper do
   context 'when redis is not available' do
 
     before(:each) do
-      Split.stub(:redis).and_raise(Errno::ECONNREFUSED)
+      Split.stub(:redis).and_raise(Errno::ECONNREFUSED.new)
     end
 
     context 'and db_failover config option is turned off' do


### PR DESCRIPTION
This pull request fixes issue #52, which deals with 5 failing tests under Rubinius, as can be seen in the following Travis CI build log: http://travis-ci.org/#!/andrew/split/builds/1389933.

Whilst I'm not entirely sure what change in Rubinius led to the failures, the simple fix is to raise an instance of `Errno::ECONNREFUSED`, rather than the class itself, as a result of calling a stubbed method. I believe this may be something to do with the way that the `ECONNREFUSED` exception class is initialised, meaning RSpec will be unable to instantiate it automatically.
