### PR TITLE
Allow versions of redis gem higher than 3

### DIFF
--- a/split.gemspec
+++ b/split.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'redis',           '~> 2.1'
-  s.add_dependency 'redis-namespace', '~> 1.1.0'
+  s.add_dependency 'redis',           '>= 2.1'
+  s.add_dependency 'redis-namespace', '>= 1.1.0'
   s.add_dependency 'sinatra',         '>= 1.2.6'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
The version 3 of the [`redis`](https://rubygems.org/gems/redis) gem is out and it looks compatible with `split`.

I updated the gemspec dependencies and the tests pass using:
- ruby 1.8.7 (2012-02-08 patchlevel 358) [i686-darwin10.8.0]
- ruby 1.8.7 (2012-02-08 MBARI 8/0x6770 on patchlevel 358) [i686-darwin10.8.0], MBARI 0x6770, Ruby Enterprise Edition 2012.02
- ruby 1.9.2p290 (2011-07-09 revision 32553) [x86_64-darwin10.8.0]
- ruby 1.9.3p194 (2012-04-20 revision 35410) [x86_64-darwin10.8.0]
- rubinius 1.2.4 (1.8.7 release 2011-07-05 JI) [x86_64-apple-darwin10.8.0]
