### PR TITLE
Allow parameter overrides, even without Redis.

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -4,6 +4,7 @@ module Split
     attr_accessor :ignore_ip_addresses
     attr_accessor :db_failover
     attr_accessor :db_failover_on_db_error
+    attr_accessor :db_failover_allow_parameter_override
     attr_accessor :allow_multiple_experiments
     attr_accessor :enabled
 
@@ -12,6 +13,7 @@ module Split
       @ignore_ip_addresses = []
       @db_failover = false
       @db_failover_on_db_error = proc{|error|} # e.g. use Rails logger here
+      @db_failover_allow_parameter_override = false
       @allow_multiple_experiments = false
       @enabled = true
     end

--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -118,7 +118,14 @@ module Split
       rescue => e
         raise unless Split.configuration.db_failover
         Split.configuration.db_failover_on_db_error.call(e)
-        ret = control_variable(control)
+        if Split.configuration.db_failover_allow_parameter_override
+          all_alternatives = *([control] + alternatives)
+          alternative_names = all_alternatives.map{|a| a.is_a?(Hash) ? a.keys : a}.flatten
+          ret = override(experiment_name, alternative_names)
+        end
+        unless ret
+          ret = control_variable(control)
+        end
       end
       ret
     end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -410,6 +410,27 @@ describe Split::Helper do
             "shared/#{alternative}"
           end.should eq('shared/blue')
         end
+
+        context 'and db_failover_allow_parameter_override config option is turned on' do
+          before(:each) do
+            Split.configure do |config|
+              config.db_failover_allow_parameter_override = true
+            end
+          end
+
+          context 'and given an override parameter' do
+            it 'should use given override instead of the first alternative' do
+              @params = {'link_color' => 'red'}
+              ab_test('link_color', 'blue', 'red').should eq('red')
+              ab_test('link_color', 'blue', 'red', 'green').should eq('red')
+              ab_test('link_color', {'blue' => 0.01}, 'red' => 0.2).should eq('red')
+              ab_test('link_color', {'blue' => 0.8}, {'red' => 20}).should eq('red')
+              ab_test('link_color', 'blue', 'red') do |alternative|
+                "shared/#{alternative}"
+              end.should eq('shared/red')
+            end
+          end
+        end
       end
 
       describe 'finished' do


### PR DESCRIPTION
Adds a new configuration option that turns on the parameter overrides, 
even when the database fails.

With this option, applications can be tested to ensure that the options
render correctly, even without Redis installed and running on the
development machines.

Specs are included.
