### PR TITLE
Fixes version number wackiness when alternatives are changed

### DIFF
--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -176,6 +176,15 @@ describe Split::Experiment do
       new_blue = Split::Alternative.new('blue', 'link_color')
       new_blue.participant_count.should eql(0)
     end
+
+    it "should only reset once" do
+      experiment = Split::Experiment.find_or_create('link_color', 'blue', 'red', 'green')
+      experiment.version.should eql(0)
+      same_experiment = Split::Experiment.find_or_create('link_color', 'blue', 'yellow', 'orange')
+      same_experiment.version.should eql(1)
+      same_experiment_again = Split::Experiment.find_or_create('link_color', 'blue', 'yellow', 'orange')
+      same_experiment_again.version.should eql(1)
+    end
   end
 
   describe 'alternatives passed as non-strings' do


### PR DESCRIPTION
I found that when I updated the alternatives in a test it kept resetting. I must have not noticed for a while, because when I checked, I was on version 30,561 yet had no results.
It turned out that when you save an existing experiment, it didn't update the alternatives, so that's what I've added.
