### PR TITLE
Fixes header gradient in FF/Opera.

### DIFF
--- a/lib/split/dashboard/public/style.css
+++ b/lib/split/dashboard/public/style.css
@@ -15,11 +15,11 @@ body {
   background: -webkit-gradient(linear, left top, left bottom,
                 color-stop(0%,#576a76),
                 color-stop(100%,#4d5256));
-  background: -moz-linear-gradient   (top, #576a76 0%, #414e58 100%);
+  background: -moz-linear-gradient(top, #576076 0%, #414e58 100%);
   background: -webkit-linear-gradient(top, #576a76 0%, #414e58 100%);
-  background: -o-linear-gradient     (top, #576a76 0%, #414e58 100%);
-  background: -ms-linear-gradient    (top, #576a76 0%, #414e58 100%);
-  background: linear-gradient        (top, #576a76 0%, #414e58 100%);
+  background: -o-linear-gradient(top, #576a76 0%, #414e58 100%);
+  background: -ms-linear-gradient(top, #576a76 0%, #414e58 100%);
+  background: linear-gradient(top, #576a76 0%, #414e58 100%);
   border-bottom: 1px solid #fff;
   -moz-border-radius-topleft:     5px;
   -webkit-border-top-left-radius: 5px;


### PR DESCRIPTION
Browsers don't like spaces between the gradient method and the arguments.

Small issue, but it bugs me as I use Firefox!
