### PR TITLE
Issue #72 - fix reseting of experiment in session

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -28,7 +28,7 @@ module Split
       if alternative_name = ab_user[experiment.key]
         alternative = Split::Alternative.new(alternative_name, experiment_name)
         alternative.increment_completion
-        session[:split].delete(experiment_name) if options[:reset]
+        ab_user.delete(experiment.key) if options[:reset]
       end
     rescue => e
       raise unless Split.configuration.db_failover

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -134,6 +134,29 @@ describe Split::Helper do
       session[:split].should eql("link_color" => alternative_name)
     end
 
+    it "should reset the users session when experiment is not versioned" do
+      experiment = Split::Experiment.find_or_create('link_color', 'blue', 'red')
+      alternative_name = ab_test('link_color', 'blue', 'red')
+
+      previous_completion_count = Split::Alternative.new(alternative_name, 'link_color').completed_count
+
+      session[:split].should eql(experiment.key => alternative_name)
+      finished('link_color', :reset => true)
+      session[:split].should eql({})
+    end
+
+    it "should reset the users session when experiment is versioned" do
+      experiment = Split::Experiment.find_or_create('link_color', 'blue', 'red')
+      experiment.increment_version
+      alternative_name = ab_test('link_color', 'blue', 'red')
+
+      previous_completion_count = Split::Alternative.new(alternative_name, 'link_color').completed_count
+
+      session[:split].should eql(experiment.key => alternative_name)
+      finished('link_color', :reset => true)
+      session[:split].should eql({})
+    end
+
     it "should do nothing where the experiment was not started by this user" do
       session[:split] = nil
       lambda { finished('some_experiment_not_started_by_the_user') }.should_not raise_exception


### PR DESCRIPTION
The issue was that versioned experiments had a different key than
non-versioned experiments.  The experiment name was equal to the
experiment key for non-versioned experiments.  Experiment#key
wraps this logic.  However, the Helper#finished method
was using the experiment_name parameter, instead of the Experiment#key
method.
