### PR TITLE
Getting negative non-finished rates when using finished(:reset => false)

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -78,7 +78,8 @@ module Split
 
     def old_versions(experiment)
       if experiment.version > 0
-        ab_user.keys.select { |k| k.match(Regexp.new(experiment.name)) }.reject { |k| k == experiment.key }
+        ab_user.keys.select { |k| k.match(Regexp.new(experiment.name)) }.
+          reject { |k| k.match(Regexp.new("^#{experiment.key}(:finished)?$")) }
       else
         []
       end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -109,6 +109,15 @@ describe Split::Helper do
       button_size_alt = Split::Alternative.new(button_size, 'button_size')
       button_size_alt.participant_count.should eql(1)
     end
+
+    it "should not over-write a finished key when an experiment is on a later version" do
+      experiment = Split::Experiment.find_or_create('link_color', 'blue', 'red')
+      experiment.increment_version
+      session[:split] = { experiment.key => 'blue', experiment.finished_key => true }
+      finshed_session = session[:split].dup
+      ab_test('link_color', 'blue', 'red')
+      session[:split].should eql(finshed_session)
+    end
   end
 
   describe 'finished' do


### PR DESCRIPTION
During testing we've found that if users go through a test that is set to not reset (finished(experiment_name, :reset => false)) and then go through again that the completion rate is incremented even though the participation rate isn't.

It turned out that the clean_old_versions method was removing the key experiment_name:version:finished key from the session.

This fix makes clean_old_versions ignore the current finished experiment as well as the current experiment.
