### PR TITLE
More issues for finished(:reset => false)

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -1,7 +1,6 @@
 module Split
   module Helper
     def ab_test(experiment_name, control, *alternatives)
-
       if RUBY_VERSION.match(/1\.8/) && alternatives.length.zero?
         puts 'WARNING: You should always pass the control alternative through as the second argument with any other alternatives as the third because the order of the hash is not preserved in ruby 1.8'
       end
@@ -67,7 +66,7 @@ module Split
     end
 
     def doing_other_tests?(experiment_key)
-      ab_user.keys.reject { |k| k == experiment_key }.length > 0
+      keys_without_experiment(ab_user.keys, experiment_key).length > 0
     end
 
     def clean_old_versions(experiment)
@@ -78,8 +77,8 @@ module Split
 
     def old_versions(experiment)
       if experiment.version > 0
-        ab_user.keys.select { |k| k.match(Regexp.new(experiment.name)) }.
-          reject { |k| k.match(Regexp.new("^#{experiment.key}(:finished)?$")) }
+        keys = ab_user.keys.select { |k| k.match(Regexp.new(experiment.name)) }
+        keys_without_experiment(keys, experiment.key)
       else
         []
       end
@@ -141,6 +140,9 @@ module Split
       ret
     end
 
+    def keys_without_experiment(keys, experiment_key)
+      keys.reject { |k| k.match(Regexp.new("^#{experiment_key}(:finished)?$")) }
+    end
   end
 
 end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -177,6 +177,12 @@ describe Split::Helper do
       session[:split] = nil
       lambda { finished('some_experiment_not_started_by_the_user') }.should_not raise_exception
     end
+
+    it 'should not be doing other tests when it has completed one that has :reset => false' do
+      ab_user[@experiment.key] = @alternative_name
+      ab_user[@experiment.finished_key] = true
+      doing_other_tests?(@experiment.key).should be false
+    end
   end
 
   describe 'conversions' do


### PR DESCRIPTION
When a user completes a test but reset is set to false, when they hit ab_test again they will get the control alternative. This is because doing_other_tests? was doing the same as issue #83 and counting the finished result as another experiment. This fixes that.
