### PR TITLE
z-score of 1.65, corresponding to the positive half of the normal curve.

### DIFF
--- a/lib/split/dashboard/helpers.rb
+++ b/lib/split/dashboard/helpers.rb
@@ -23,11 +23,11 @@ module Split
 
       if z == 0.0
         'No Change'
-      elsif z < 1.96
+      elsif z < 1.645
         'no confidence'
-      elsif z < 2.57
+      elsif z < 1.96
         '95% confidence'
-      elsif z < 3.29
+      elsif z < 2.57
         '99% confidence'
       else
         '99.9% confidence'

--- a/spec/dashboard_helpers_spec.rb
+++ b/spec/dashboard_helpers_spec.rb
@@ -9,12 +9,9 @@ describe Split::DashboardHelpers do
       confidence_level(Complex(2e-18, -0.03)).should eql('No Change')
     end
 
-    it "should consider a z-score of 1.96 < z < 2.57 as 95% confident" do
-      confidence_level(2.12).should eql('95% confidence')
+    it "should consider a z-score of 1.645 < z < 1.96 as 95% confident" do
+      confidence_level(1.80).should eql('95% confidence')
     end
 
-    it "should consider a z-score of -1.96 > z > -2.57 as 95% confident" do
-      confidence_level(-2.12).should eql('95% confidence')
-    end
   end
 end


### PR DESCRIPTION
Fix for #94

We are not interested in negative z numbers. The null hypothesis is
that the control is not performing worse. We only have to be confident
it's better to disprove the null hypothese, which means we only care
about the positive tail of the normal distribution.
