### PR TITLE
Bug in preloaded config when called multiple times

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -193,6 +193,7 @@ module Split
         end
         [variants.shift, variants.inject({}, :merge)]
       else
+        variants = variants.dup
         [variants.shift, variants]
       end
     end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -586,6 +586,14 @@ describe Split::Helper do
       ab_test :my_experiment
     end
 
+    it "can be called multiple times" do
+      Split.configuration.experiments[:my_experiment] = {
+        :variants => [ "control_opt", "other_opt" ],
+      }
+      should_receive(:experiment_variable).with(["other_opt"], "control_opt", :my_experiment).exactly(5).times
+      5.times { ab_test :my_experiment }
+    end
+
     it "accepts multiple variants" do
       Split.configuration.experiments[:my_experiment] = {
         :variants => [ "control_opt", "second_opt", "third_opt" ],


### PR DESCRIPTION
I introduced a bug in the preloaded config code due to some careless array mutation. Fix + regression test.
