### PR TITLE
Alternatives passed wrong from config

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -191,7 +191,7 @@ module Split
             { v => unassigned_probability }
           end
         end
-        [variants.shift, [variants.inject({}, :merge)]]
+        [variants.shift, variants]
       else
         variants = variants.dup
         [variants.shift, variants]

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -584,11 +584,11 @@ describe Split::Helper do
         @control ||= anything
         @alternatives ||= anything
         @times ||= 1
-        actual.should_receive(:experiment_variable).with([@alternatives].flatten, @control, name).exactly(@times).times
+        actual.should_receive(:experiment_variable).with(@alternatives, @control, name).exactly(@times).times
       end
-      chain :with do |control, alternatives|
+      chain :with do |control, *alternatives|
         @control = control
-        @alternatives = alternatives
+        @alternatives = alternatives.flatten
       end
       chain :exactly do |times|
         @times = times
@@ -628,7 +628,7 @@ describe Split::Helper do
           { :name => "third_opt", :percent => 23 },
         ],
       }
-      should start_experiment(:my_experiment).with({"control_opt" => 0.67}, {"second_opt" => 0.1, "third_opt" => 0.23})
+      should start_experiment(:my_experiment).with({"control_opt" => 0.67}, {"second_opt" => 0.1}, {"third_opt" => 0.23})
       ab_test :my_experiment
     end
 
@@ -641,7 +641,7 @@ describe Split::Helper do
           "fourth_opt",
         ],
       }
-      should start_experiment(:my_experiment).with({"control_opt" => 0.34}, {"second_opt" => 0.215, "third_opt" => 0.23, "fourth_opt" => 0.215})
+      should start_experiment(:my_experiment).with({"control_opt" => 0.34}, {"second_opt" => 0.215}, {"third_opt" => 0.23}, {"fourth_opt" => 0.215})
       ab_test :my_experiment
     end
 
@@ -653,7 +653,7 @@ describe Split::Helper do
           { :name => "third_opt", :percent => 64 },
         ],
       }
-      should start_experiment(:my_experiment).with({"control_opt" => 0.18}, {"second_opt" => 0.18, "third_opt" => 0.64})
+      should start_experiment(:my_experiment).with({"control_opt" => 0.18}, {"second_opt" => 0.18}, {"third_opt" => 0.64})
       ab_test :my_experiment
     end
   end


### PR DESCRIPTION
Another bug I encountered when using probabilities in the config file, due to my misunderstanding a param. Also making the specs a bit more semantic.
