### PR TITLE
Handle exceptions from invalid JSON in cookies

### DIFF
--- a/lib/split/persistence/cookie_adapter.rb
+++ b/lib/split/persistence/cookie_adapter.rb
@@ -36,7 +36,15 @@ module Split
       end
 
       def hash
-        @cookies[:split] ? JSON.parse(@cookies[:split]) : {}
+        if @cookies[:split]
+          begin
+            JSON.parse(@cookies[:split])
+          rescue JSON::ParserError
+            {}
+          end
+        else
+          {}
+        end
       end
 
     end

--- a/spec/persistence/cookie_adapter_spec.rb
+++ b/spec/persistence/cookie_adapter_spec.rb
@@ -28,4 +28,11 @@ describe Split::Persistence::CookieAdapter do
     end
   end
 
+  it "handles invalid JSON" do
+    context.cookies[:split] = { :value => '{"foo":2,', :expires => Time.now }
+    subject["my_key"].should be_nil
+    subject["my_key"] = "my_value"
+    subject["my_key"].should eq("my_value")
+  end
+
 end


### PR DESCRIPTION
We've been getting some errors from people who somehow got truncated values in their Split cookies. Seems like the safe thing to do here is just reset the hash.
