### PR TITLE
Fixed robot regexp escaping

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -138,7 +138,7 @@ module Split
     end
 
     def initialize
-      @robot_regex = /\b(#{BOTS.keys.join('|')})\b|\A\W*\z/i
+      @robot_regex = /\b(?:#{escaped_bots.join('|')})\b|\A\W*\z/i
       @ignore_ip_addresses = []
       @db_failover = false
       @db_failover_on_db_error = proc{|error|} # e.g. use Rails logger here
@@ -156,6 +156,10 @@ module Split
       if hash.kind_of?(Hash)
         hash[key.to_s] || hash[key.to_sym]
       end
+    end
+
+    def escaped_bots
+      BOTS.map { |key, _| Regexp.escape(key) }
     end
   end
 end


### PR DESCRIPTION
It's necessary to escape values in regexps, example:

``` ruby
/awe.sm/ =~ 'aweXsm' #=> 0
```

Also replaced `^$` with `\A\z`.
