### PR TITLE
require yaml as it is not loaded in 2.0.0-p0 by default

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'split'
 require 'ostruct'
+require 'yaml'
 require 'complex' if RUBY_VERSION.match(/1\.8/)
 
 Dir['./spec/support/*.rb'].each { |f| require f }


### PR DESCRIPTION
`configuration_spec` fails with ruby 2.0.0-p0 when yaml is not required
