### PR TITLE
Adding missing namespace for "Outside of a web session" example

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -485,7 +485,7 @@ conduct experiments that are not tied to a web session.
 # create a new experiment
 experiment = Split::Experiment.find_or_create('color', 'red', 'blue')
 # create a new trial
-trial = Trial.new(:experiment => experiment)
+trial = Split::Trial.new(:experiment => experiment)
 # run trial
 trial.choose!
 # get the result, returns either red or blue


### PR DESCRIPTION
Adding namespace `Split` to trial initalisation
