### PR TITLE
Adding possibility to store overridden alternative

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -162,7 +162,7 @@ If you have an experiment called `button_color` with alternatives called `red` a
 
     http://myawesomesite.com?button_color=red
 
-will always have red buttons. This won't be stored in your session or count towards to results.
+will always have red buttons. This won't be stored in your session or count towards to results, unless you set the `store_override` configuration option.
 
 ### Reset after completion
 

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -11,6 +11,7 @@ module Split
     attr_accessor :enabled
     attr_accessor :persistence
     attr_accessor :algorithm
+    attr_accessor :store_override
 
     attr_reader :experiments
 

--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -166,6 +166,7 @@ module Split
       experiment = trial.experiment
       if override_present?(experiment.name)
         ret = override_alternative(experiment.name)
+        ab_user[experiment.key] = ret if Split.configuration.store_override
       elsif ! experiment.winner.nil?
         ret = experiment.winner.name
       else

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -26,6 +26,10 @@ describe Split::Configuration do
     @config.disabled?.should be_true
   end
 
+  it "should not store the overridden test group per default" do
+    @config.store_override.should be_false
+  end
+
   it "should provide a default pattern for robots" do
     %w[Baidu Gigabot Googlebot libwww-perl lwp-trivial msnbot SiteUptime Slurp WordPress ZIBB ZyBorg YandexBot AdsBot-Google Wget curl bitlybot facebookexternalhit spider].each do |robot|
       @config.robot_regex.should =~ robot

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -96,6 +96,22 @@ describe Split::Helper do
       alternative.should eql('red')
     end
 
+    it "should not store the via params forced alternative" do
+      @params = {'link_color' => 'blue'}
+      ab_user.should_not_receive(:[]=)
+      ab_test('link_color', 'blue', 'red')
+    end
+
+    context "when store_override is set" do
+      before { Split.configuration.store_override = true }
+
+      it "should store the forced alternative" do
+        @params = {'link_color' => 'blue'}
+        ab_user.should_receive(:[]=).with('link_color', 'blue')
+        ab_test('link_color', 'blue', 'red')
+      end
+    end
+
     it "should allow passing a block" do
       alt = ab_test('link_color', 'blue', 'red')
       ret = ab_test('link_color', 'blue', 'red') { |alternative| "shared/#{alternative}" }


### PR DESCRIPTION
We need to persist the overridden test group during our tests, because it's not always possible to pass the test group on every request (especially on subsequent AJAX requests).

This PR adds a configuration option called `store_override` (disabled by default). When enabled, split stores the overridden test group for subsequent requests.
