### PR TITLE
Stores and parses Experiment's start_time as a UNIX integer.

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -65,7 +65,7 @@ module Split
 
       if new_record?
         Split.redis.sadd(:experiments, name)
-        Split.redis.hset(:experiment_start_times, @name, Time.now)
+        Split.redis.hset(:experiment_start_times, @name, Time.now.to_i)
         @alternatives.reverse.each {|a| Split.redis.lpush(name, a.name)}
         @goals.reverse.each {|a| Split.redis.lpush(goals_key, a)} unless @goals.nil?
       else
@@ -157,7 +157,14 @@ module Split
 
     def start_time
       t = Split.redis.hget(:experiment_start_times, @name)
-      Time.parse(t) if t
+      if t
+        # Check if stored time is an integer
+        if t =~ /^[-+]?[0-9]+$/
+          t = Time.at(t.to_i)
+        else
+          t = Time.parse(t)
+        end
+      end
     end
 
     def next_alternative

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -44,7 +44,7 @@ describe Split::Experiment do
     end
 
     it "should save the start time to redis" do
-      experiment_start_time = Time.parse("Sat Mar 03 14:01:03")
+      experiment_start_time = Time.at(1372167761)
       Time.stub(:now => experiment_start_time)
       experiment.save
 
@@ -57,6 +57,15 @@ describe Split::Experiment do
       experiment.save
 
       Split::Experiment.find('basket_text').algorithm.should == experiment_algorithm
+    end
+
+    it "should handle having a start time stored as a string" do
+      experiment_start_time = Time.parse("Sat Mar 03 14:01:03")
+      Time.stub(:now => experiment_start_time)
+      experiment.save
+      Split.redis.hset(:experiment_start_times, experiment.name, experiment_start_time)
+
+      Split::Experiment.find('basket_text').start_time.should == experiment_start_time
     end
 
     it "should handle not having a start time" do


### PR DESCRIPTION
Currently, an Experiment's start_time is stored using Time's to_s method. If this is overridden, parsing fails when the date is later retrieved. Instead, I suggest using UNIX integer timestamps. Though UNIX integer representations are used, they are stored as strings and are backwards compatable with prior representations.
