### PR TITLE
Ensure request is defined before calling methods on it

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -135,14 +135,14 @@ module Split
     end
 
     def is_robot?
-      request.user_agent =~ Split.configuration.robot_regex
+      defined?(request) && request.user_agent =~ Split.configuration.robot_regex
     end
 
     def is_ignored_ip_address?
       return false if Split.configuration.ignore_ip_addresses.empty?
 
       Split.configuration.ignore_ip_addresses.each do |ip|
-        return true if request.ip == ip || (ip.class == Regexp && request.ip =~ ip)
+        return true if defined?(request) && (request.ip == ip || (ip.class == Regexp && request.ip =~ ip))
       end
       false
     end


### PR DESCRIPTION
In #is_robot? and #is_ignore_ip_address?, request is assumed to be accessible.
As a result, the Split::Helper module can only really be included in a
Controller context.

This commit removes that requirement by conditionally checking that request is
defined by attempting to call methods on it.
