### PR TITLE
Made Rails ENV display conditional on Rails environment existing using controller; otherwise fallback on Rack version

### DIFF
--- a/lib/split/dashboard.rb
+++ b/lib/split/dashboard.rb
@@ -16,6 +16,12 @@ module Split
 
     get '/' do
       @experiments = Split::Experiment.all
+      #Display Rails Environment mode (or Rack version if not using Rails)
+      if Object.const_defined?('Rails')
+        @current_env = Rails.env.titlecase
+      else
+        @current_env = "Rack: #{Rack.version}"
+      end
       erb :index
     end
 

--- a/lib/split/dashboard/views/layout.erb
+++ b/lib/split/dashboard/views/layout.erb
@@ -11,7 +11,7 @@
 <body>
   <div class="header">
     <h1>Split Dashboard</h1>
-    <p class="environment"><%= Rails.env.titlecase %></p>
+    <p class="environment"><%= @current_env %></p>
   </div>
 
   <div id="main">


### PR DESCRIPTION
For your consideration;

Checks existence of Rails; otherwise assigns current Rack version to instance variable for display in view.

Update to Feature Addition re Issue #186, and #187

No prob if it's a no-go; let me know if there's anything further you can do with it though.  Showing current Rails environment in the dashboard could definitely be helpful across distributed setups with production, staging, sandbox, development, and so on; so I welcome any suggestions if you think it can work.
