### PR TITLE
Fix whiplash algorithm when using goals

### DIFF
--- a/lib/split/algorithms/whiplash.rb
+++ b/lib/split/algorithms/whiplash.rb
@@ -10,23 +10,23 @@ module Split
       end
 
       private
-      
+
       def self.arm_guess(participants, completions)
         a = [participants, 0].max
         b = [participants-completions, 0].max
         s = SimpleRandom.new; s.set_seed; s.beta(a+fairness_constant, b+fairness_constant)
       end
-      
+
       def self.best_guess(alternatives)
         guesses = {}
-        alternatives.each do |alternative| 
-          guesses[alternative.name] = arm_guess(alternative.participant_count, alternative.completed_count) 
+        alternatives.each do |alternative|
+          guesses[alternative.name] = arm_guess(alternative.participant_count, alternative.all_completed_count)
         end
         gmax = guesses.values.max
         best = guesses.keys.select {|name| guesses[name] ==  gmax }
         return best.sample
       end
-      
+
       def self.fairness_constant
         7
       end


### PR DESCRIPTION
Use all_completed_count instead of completed_count to take goal completions into account. Sorry about all of the seemingly extraneous changes but my editor config removes extra whitespace and adds a linebreak at the end.
