### PR TITLE
Only trigger completion callback with valid Trial

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -62,8 +62,7 @@ module Split
       else
         alternative_name = ab_user[experiment.key]
         trial = Trial.new(:experiment => experiment, :alternative => alternative_name, :goals => options[:goals])
-        trial.complete!
-        call_trial_complete_hook(trial)
+        call_trial_complete_hook(trial) if trial.complete!
 
         if should_reset
           reset!(experiment)

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -261,6 +261,12 @@ describe Split::Helper do
         self.should_receive(:some_method)
         finished(@experiment_name)
       end
+
+      it "should not call the method without alternative" do
+        ab_user[@experiment.key] = nil
+        self.should_not_receive(:some_method)
+        finished(@experiment_name)
+      end
     end
 
   end


### PR DESCRIPTION
Previously it was possible to trigger the #on_trial_complete even if the Trial
wasn't legally completed (eg #complete! was falsey). This can occur if the user
reaches a #finished call before they reach an #ab_test call.
