### PR TITLE
Starting tests manually

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -165,6 +165,13 @@ If you have an experiment called `button_color` with alternatives called `red` a
 
 will always have red buttons. This won't be stored in your session or count towards to results, unless you set the `store_override` configuration option.
 
+### Starting experiments manually
+
+By default new AB tests will be active right after deployment. In case you would like to start new test a while after
+the deploy, you can do it by setting the `start_manually` configuration option to `true`.
+
+After choosing this option tests won't be started right after deploy, but after pressing the `Start` button in Split admin dashboard.
+
 ### Reset after completion
 
 When a user completes a test their session is reset so that they may start the test again in the future.
@@ -336,6 +343,7 @@ Split.configure do |config|
   config.allow_multiple_experiments = true
   config.enabled = true
   config.persistence = Split::Persistence::SessionAdapter
+  #config.start_manually = false ## new test will have to be started manually from the admin panel. default false
 end
 ```
 

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -12,6 +12,7 @@ module Split
     attr_accessor :persistence
     attr_accessor :algorithm
     attr_accessor :store_override
+    attr_accessor :start_manually
     attr_accessor :on_trial_choose
     attr_accessor :on_trial_complete
     attr_accessor :on_experiment_reset

--- a/lib/split/dashboard.rb
+++ b/lib/split/dashboard.rb
@@ -33,6 +33,12 @@ module Split
       redirect url('/')
     end
 
+    post '/start/:experiment' do
+      @experiment = Split::Experiment.find(params[:experiment])
+      @experiment.start
+      redirect url('/')
+    end
+
     post '/reset/:experiment' do
       @experiment = Split::Experiment.find(params[:experiment])
       @experiment.reset

--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -14,9 +14,15 @@
     <% if goal.nil? %>
       <div class='inline-controls'>
         <small><%= experiment.start_time ? experiment.start_time.strftime('%Y-%m-%d') : 'Unknown' %></small>
-        <form action="<%= url "/reset/#{experiment.name}" %>" method='post' onclick="return confirmReset()">
-          <input type="submit" value="Reset Data">
-        </form>
+        <% if experiment.start_time %>
+          <form action="<%= url "/reset/#{experiment.name}" %>" method='post' onclick="return confirmReset()">
+            <input type="submit" value="Reset Data">
+          </form>
+        <% else%>
+          <form action="<%= url "/start/#{experiment.name}" %>" method='post'>
+            <input type="submit" value="Start">
+          </form>
+        <% end %>
         <form action="<%= url "/#{experiment.name}" %>" method='post' onclick="return confirmDelete()">
           <input type="hidden" name="_method" value="delete"/>
           <input type="submit" value="Delete" class="red">

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -70,7 +70,7 @@ module Split
 
       if new_record?
         Split.redis.sadd(:experiments, name)
-        Split.redis.hset(:experiment_start_times, @name, Time.now.to_i)
+        start unless Split.configuration.start_manually
         @alternatives.reverse.each {|a| Split.redis.lpush(name, a.name)}
         @goals.reverse.each {|a| Split.redis.lpush(goals_key, a)} unless @goals.nil?
       else
@@ -158,6 +158,10 @@ module Split
 
     def reset_winner
       Split.redis.hdel(:experiment_winner, name)
+    end
+
+    def start
+      Split.redis.hset(:experiment_start_times, @name, Time.now.to_i)
     end
 
     def start_time

--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -173,7 +173,7 @@ module Split
         ret = experiment.winner.name
       else
         clean_old_versions(experiment)
-        if exclude_visitor? || not_allowed_to_test?(experiment.key)
+        if exclude_visitor? || not_allowed_to_test?(experiment.key) || not_started?(experiment)
           ret = experiment.control.name
         else
           if ab_user[experiment.key]
@@ -187,6 +187,10 @@ module Split
       end
 
       ret
+    end
+
+    def not_started?(experiment)
+      experiment.start_time.nil?
     end
 
     def call_trial_choose_hook(trial)

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -25,6 +25,16 @@ describe Split::Dashboard do
     last_response.should be_ok
   end
 
+  it "should start experiment" do
+    Split.configuration.start_manually = true
+    experiment
+    get '/'
+    last_response.body.should include('Start')
+
+    post "/start/#{experiment.name}"
+    get '/'
+    last_response.body.should include('Reset Data')
+  end
 
   it "should reset an experiment" do
     red_link.participant_count = 5

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -51,6 +51,13 @@ describe Split::Experiment do
       Split::Experiment.find('basket_text').start_time.should == experiment_start_time
     end
 
+    it "should not save the start time to redis when start_manually is enabled" do
+      Split.configuration.stub(:start_manually => true)
+      experiment.save
+
+      Split::Experiment.find('basket_text').start_time.should be_nil
+    end
+
     it "should save the selected algorithm to redis" do
       experiment_algorithm = Split::Algorithms::Whiplash
       experiment.algorithm = experiment_algorithm
@@ -148,7 +155,7 @@ describe Split::Experiment do
       e.should == experiment
       e.algorithm.should == Split::Algorithms::Whiplash
     end
-    
+
     it "should persist a new experiment in redis, that does not exist in the configuration file" do
       experiment = Split::Experiment.new('foobar', :alternatives => ['tra', 'la'], :algorithm => Split::Algorithms::Whiplash)
       experiment.save

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -71,6 +71,15 @@ describe Split::Helper do
       }.should_not change { e.participant_count }
     end
 
+    it 'should not increment the counter for an not started experiment' do
+      Split.configuration.stub(:start_manually => true)
+      e = Split::Experiment.find_or_create('button_size', 'small', 'big')
+      lambda {
+        a = ab_test('button_size', 'small', 'big')
+        a.should eq('small')
+      }.should_not change { e.participant_count }
+    end
+
     it "should return the given alternative for an existing user" do
       alternative = ab_test('link_color', 'blue', 'red')
       repeat_alternative = ab_test('link_color', 'blue', 'red')


### PR DESCRIPTION
In some cases it is useful to have the possibility to start test manually, for example:
- Tests that are designed to run for short time in a specific time frame
- Tests that require longer development and are deployed in multiple iterations, but can be started just together

This PR introduces a configuration option `start_manully` that allows to start each test from the split dashboard by pressing a "Start" button which is located in place of "Reset Data".
