### PR TITLE
[BUG] Display Start button when rendering an experiment with a goal defined

### DIFF
--- a/lib/split/dashboard/views/_controls.erb
+++ b/lib/split/dashboard/views/_controls.erb
@@ -1,0 +1,13 @@
+<% if experiment.start_time %>
+  <form action="<%= url "/reset/#{experiment.name}" %>" method='post' onclick="return confirmReset()">
+    <input type="submit" value="Reset Data">
+  </form>
+<% else%>
+  <form action="<%= url "/start/#{experiment.name}" %>" method='post'>
+    <input type="submit" value="Start">
+  </form>
+<% end %>
+<form action="<%= url "/#{experiment.name}" %>" method='post' onclick="return confirmDelete()">
+  <input type="hidden" name="_method" value="delete"/>
+  <input type="submit" value="Delete" class="red">
+</form>

--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -14,19 +14,7 @@
     <% if goal.nil? %>
       <div class='inline-controls'>
         <small><%= experiment.start_time ? experiment.start_time.strftime('%Y-%m-%d') : 'Unknown' %></small>
-        <% if experiment.start_time %>
-          <form action="<%= url "/reset/#{experiment.name}" %>" method='post' onclick="return confirmReset()">
-            <input type="submit" value="Reset Data">
-          </form>
-        <% else%>
-          <form action="<%= url "/start/#{experiment.name}" %>" method='post'>
-            <input type="submit" value="Start">
-          </form>
-        <% end %>
-        <form action="<%= url "/#{experiment.name}" %>" method='post' onclick="return confirmDelete()">
-          <input type="hidden" name="_method" value="delete"/>
-          <input type="submit" value="Delete" class="red">
-        </form>
+        <%= erb :_controls, :locals => {:experiment => experiment} %>
       </div>
     <% end %>
   </div>

--- a/lib/split/dashboard/views/_experiment_with_goal_header.erb
+++ b/lib/split/dashboard/views/_experiment_with_goal_header.erb
@@ -2,13 +2,7 @@
   <div class="experiment-header">
       <div class='inline-controls'>
         <small><%= experiment.start_time ? experiment.start_time.strftime('%Y-%m-%d') : 'Unknown' %></small>
-        <form action="<%= url "/reset/#{experiment.name}" %>" method='post' onclick="return confirmReset()">
-          <input type="submit" value="Reset Data">
-        </form>
-        <form action="<%= url "/#{experiment.name}" %>" method='post' onclick="return confirmDelete()">
-          <input type="hidden" name="_method" value="delete"/>
-          <input type="submit" value="Delete" class="red">
-        </form>
+        <%= erb :_controls, :locals => {:experiment => experiment} %>
       </div>
   </div>
 </div>

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -14,7 +14,11 @@ describe Split::Dashboard do
   end
 
   let(:experiment) {
-    Split::Experiment.find_or_create('link_color', 'blue', 'red')
+    Split::Experiment.find_or_create("link_color", "blue", "red")
+  }
+
+  let(:experiment_with_goals) {
+    Split::Experiment.find_or_create({"link_color" => ["goal_1", "goal_2"]}, "blue", "red")
   }
 
   let(:red_link) { link("red") }
@@ -25,15 +29,34 @@ describe Split::Dashboard do
     last_response.should be_ok
   end
 
-  it "should start experiment" do
-    Split.configuration.start_manually = true
-    experiment
-    get '/'
-    last_response.body.should include('Start')
+  context "start experiment manually" do
+    before do
+      Split.configuration.start_manually = true
+    end
 
-    post "/start/#{experiment.name}"
-    get '/'
-    last_response.body.should include('Reset Data')
+    context "experiment without goals" do
+      it "should display a Start button" do
+        experiment
+        get '/'
+        last_response.body.should include('Start')
+
+        post "/start/#{experiment.name}"
+        get '/'
+        last_response.body.should include('Reset Data')
+      end
+    end
+
+    context "with goals" do
+      it "should display a Start button" do
+        experiment_with_goals
+        get '/'
+        last_response.body.should include('Start')
+
+        post "/start/#{experiment.name}"
+        get '/'
+        last_response.body.should include('Reset Data')
+      end
+    end
   end
 
   it "should reset an experiment" do


### PR DESCRIPTION
If an experiment has goals and manually_start is set to true in the configuration, no Start button is displayed in the dashboard.
