### PR TITLE
Added reset_on_experiment_changes option

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -18,6 +18,7 @@ module Split
     attr_accessor :on_experiment_reset
     attr_accessor :on_experiment_delete
     attr_accessor :include_rails_helper
+    attr_accessor :reset_on_experiment_changes
 
     attr_reader :experiments
 
@@ -195,6 +196,7 @@ module Split
       @persistence = Split::Persistence::SessionAdapter
       @algorithm = Split::Algorithms::WeightedSample
       @include_rails_helper = true
+      @reset_on_experiment_changes = true
     end
 
     private

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -70,6 +70,10 @@ describe Split::Configuration do
     @config.experiment_for(:my_experiment).should == {:alternatives=>["control_opt", ["other_opt"]]}
   end
 
+  it "should provide a default value for reset_on_experiment_changes" do
+    @config.reset_on_experiment_changes.should be_true
+  end
+
   context "when experiments are defined via YAML" do
     context "as strings" do
       context "in a basic configuration" do


### PR DESCRIPTION
As previously discussed, I added a `reset_on_experiment_changes` configuration option. Default behaviour did not change (default value is `true`).
