### PR TITLE
Adding Split::Cacheable to Extensions List on README

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -631,6 +631,7 @@ end
   - [Split::Export](http://github.com/andrew/split-export) - easily export ab test data out of Split
   - [Split::Analytics](http://github.com/andrew/split-analytics) - push test data to google analytics
   - [Split::Mongoid](https://github.com/MongoHQ/split-mongoid) - store experiment data in mongoid (still uses redis)
+  - [Split::Cacheable](https://github.com/harrystech/split_cacheable) - automatically create cache buckets per test
 
 ## Screencast
 


### PR DESCRIPTION
Hey!

We made this great gem that automatically creates cache buckets for each Split Test + Variation. Take a look at our README to get a better idea of how we use it. Was wondering if you might consider accepting this PR to add our gem/extension to your list. 

We're gonna write a tech blog post about it in the next few weeks. 
