### PR TITLE
Provide an option to generically disable Split

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -179,6 +179,12 @@ If you have an experiment called `button_color` with alternatives called `red` a
 
 will always have red buttons. This won't be stored in your session or count towards to results, unless you set the `store_override` configuration option.
 
+In the event you want to disable all tests without having to know the individual experiment names, add a `SPLIT_DISABLE` query parameter.
+
+    http://myawesomesite.com?SPLIT_DISABLE=trues
+
+It is not required to send `SPLIT_DISABLE=false` to activate Split.
+
 ### Starting experiments manually
 
 By default new AB tests will be active right after deployment. In case you would like to start new test a while after

--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -31,8 +31,9 @@ module Split
         raise(e) unless Split.configuration.db_failover
         Split.configuration.db_failover_on_db_error.call(e)
 
-        if Split.configuration.db_failover_allow_parameter_override && override_present?(experiment_name)
-          ret = override_alternative(experiment_name)
+        if Split.configuration.db_failover_allow_parameter_override
+          ret = override_alternative(experiment_name) if override_present?(experiment_name)
+          ret = control_variable(control) if split_generically_disabled?
         end
       ensure
         ret ||= control_variable(control)
@@ -95,6 +96,10 @@ module Split
 
     def override_alternative(experiment_name)
       params[experiment_name] if override_present?(experiment_name)
+    end
+
+    def split_generically_disabled?
+      defined?(params) && params[:SPLIT_DISABLE]
     end
 
     def begin_experiment(experiment, alternative_name = nil)
@@ -168,6 +173,9 @@ module Split
       experiment = trial.experiment
       if override_present?(experiment.name)
         ret = override_alternative(experiment.name)
+        ab_user[experiment.key] = ret if Split.configuration.store_override
+      elsif split_generically_disabled?
+        ret = experiment.control.name
         ab_user[experiment.key] = ret if Split.configuration.store_override
       elsif experiment.has_winner?
         ret = experiment.winner.name

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -107,6 +107,24 @@ describe Split::Helper do
       ab_test('link_color', 'blue', 'red')
     end
 
+    it "SPLIT_DISABLE query parameter should also force the alternative (uses control)" do
+      @params = {'SPLIT_DISABLE' => 'true'}
+      alternative = ab_test('link_color', 'blue', 'red')
+      alternative.should eql('blue')
+      alternative = ab_test('link_color', {'blue' => 1}, 'red' => 5)
+      alternative.should eql('blue')
+      alternative = ab_test('link_color', 'red', 'blue')
+      alternative.should eql('red')
+      alternative = ab_test('link_color', {'red' => 5}, 'blue' => 1)
+      alternative.should eql('red')
+    end
+
+    it "should not store the split when Split generically disabled" do
+      @params = {'SPLIT_DISABLE' => 'true'}
+      ab_user.should_not_receive(:[]=)
+      ab_test('link_color', 'blue', 'red')
+    end
+
     context "when store_override is set" do
       before { Split.configuration.store_override = true }
 


### PR DESCRIPTION
This is roughly what I'm trying to achieve, but it's not passing the tests I added in this format.  Not quite sure why.

It passes your old tests, but not the new ones I've put in.

```
  1) Split::Helper ab_test should not store the split when Split generically disabled
     Failure/Error: ab_test('link_color', 'blue', 'red')
       ({}).[]=("link_color", "blue")
           expected: 0 times with any arguments
           received: 1 time with arguments: ("link_color", "blue")
     # ./lib/split/helper.rb:107:in `begin_experiment'
     # ./lib/split/helper.rb:191:in `start_trial'
     # ./lib/split/helper.rb:26:in `ab_test'
     # ./spec/helper_spec.rb:125:in `block (3 levels) in <top (required)>'

  2) Split::Helper ab_test SPLIT_DISABLE query parameter should also force the alternative (uses control)
     Failure/Error: alternative.should eql('blue')

       expected: "blue"
            got: "red"

       (compared using eql?)
     # ./spec/helper_spec.rb:113:in `block (3 levels) in <top (required)>'
```
