### PR TITLE
Call compact within Split::ExperimentCatalog.all

### DIFF
--- a/lib/split/experiment_catalog.rb
+++ b/lib/split/experiment_catalog.rb
@@ -1,7 +1,9 @@
 module Split
   class ExperimentCatalog
+    # Return all experiments
     def self.all
-      Split.redis.smembers(:experiments).map {|e| find(e)}
+      # Call compact to prevent nil experiments from being returned -- seems to happen during gem upgrades
+      Split.redis.smembers(:experiments).map {|e| find(e)}.compact
     end
 
     # Return experiments without a winner (considered "active") first


### PR DESCRIPTION
In certain upgrade situations the ExperimentCatalog could return nil for an experiment. This goes against some assumptions about the public api and how it is used. Call compact to prevent nil from being returned.
