### PR TITLE
support multiple metrics per experiment

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -85,6 +85,7 @@ module Split
         'DigitalPersona Fingerprint Software' => 'HP Fingerprint scanner',
         'ShowyouBot' => 'Showyou iOS app spider',
         'ZyBorg' => 'Zyborg? Hmmm....',
+        'ELB-HealthChecker' => 'ELB Health Check'
       }
     end
 


### PR DESCRIPTION
Allows experiments to support multiple "generic conversions" aka metrics. For example, [:add_to_cart, :purchase]. This way, triggering either finished(:add_to_cart) or finished(:purchase) will trigger a conversion on the experiment. 

My intended usage is to do finished(:add_to_cart => "add_to_cart") and finished(:purchase => "purchase") in order to track separate goals with metrics. I didn't try to automate it in order to maintain flexibility and backwards compatibility. Same with the name of the hash "metric." I would like to change it to "metrics" but that would break backwards compatibility. 

I don't fully understand the original intended use cases for metrics but from my point of view, it seems it should just automatically trigger conversions for a goal of the same name. In a sense, I see metrics as "universal goals" vs "experiment-specific goals." 

Does that make sense? 
