### PR TITLE
Experiments with single-quotes break "Use This" functionality

### DIFF
--- a/lib/split/dashboard/helpers.rb
+++ b/lib/split/dashboard/helpers.rb
@@ -1,5 +1,9 @@
 module Split
   module DashboardHelpers
+    def h(text)
+      Rack::Utils.escape_html(text)
+    end
+
     def url(*path_parts)
       [ path_prefix, path_parts ].join("/").squeeze('/')
     end

--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -71,7 +71,7 @@
             <% end %>
           <% else %>
             <form action="<%= url experiment.name %>" method='post' onclick="return confirmWinner()">
-              <input type='hidden' name='alternative' value='<%= alternative.name %>'>
+              <input type='hidden' name='alternative' value='<%= h alternative.name %>'>
               <input type="submit" value="Use this" class="green">
             </form>
           <% end %>


### PR DESCRIPTION
If any experiment name contains a single quote, the lack of escaping in the dashboard causes a misnamed experiment (e.g. "You'll Love It" becomes "You") to be declared the winner, leaving all experiments looking like Losers and associated ab_test getting back a name it wasn't expecting.

(Escape mechanism is taken from http://www.sinatrarb.com/faq.html#escape_html)
