### PR TITLE
added required params to example

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -354,7 +354,7 @@ end
 
 You can even use Devise or any other Warden-based authentication method to authorize users. Just replace `mount Split::Dashboard, :at => 'split'` in `config/routes.rb` with the following:
 ```ruby
-match "/split" => Split::Dashboard, :anchor => false, :constraints => lambda { |request|
+match "/split" => Split::Dashboard, :anchor => false, :via => [:get, :post], :constraints => lambda { |request|
   request.env['warden'].authenticated? # are we authenticated?
   request.env['warden'].authenticate! # authenticate if not already
   # or even check any other condition such as request.env['warden'].user.is_admin?


### PR DESCRIPTION
it would be great if you would include this. It would prevent a user to run over an error when copy&pasting the example code. 

Thanks for the great gem, btw. 

Cheers, 
Thomas :) 
