### PR TITLE
If the DNS resolution fails for your redis server, ruby will throw a SocketError, which is currently not rescued by the ab_test helper

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -16,7 +16,7 @@ module Split
         else
           control_variable(experiment.control)
         end
-      rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
+      rescue Errno::ECONNREFUSED, Redis::CannotConnectError, SocketError => e
         raise(e) unless Split.configuration.db_failover
         Split.configuration.db_failover_on_db_error.call(e)
 


### PR DESCRIPTION
Protip: Don't delete a redis instance your production server is currently using.

If wanted, I can add both:
1. Checking for the specific error message DNS resolution failures produce: `getaddrinfo: Name or service not known`
2. A test for raising this specific error, though I'm not exactly where it should go. The `helper_spec.rb` file does have tests for redis being unavailable, but it currently only tests the raise of `Errno::ECONNREFUSED` and not `Redis::CannotConnectError`.