### PR TITLE
Don't check for capture presence in ab_test

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -29,13 +29,7 @@ module Split
       end
 
       if block_given?
-        if defined?(capture) # a block in a rails view
-          block = Proc.new { yield(alternative, (trial.metadata if trial)) }
-          concat(capture(alternative, &block))
-          false
-        else
-          yield(alternative, (trial.metadata if trial))
-        end
+        yield(alternative, (trial.metadata if trial))
       else
         alternative
       end


### PR DESCRIPTION
Since this code was previously merged, Rails has changed and currently
(at 4.2) this code has not been working in controllers, because the
condition was true also for capture method from Kernel::Reporting module
from Rails.