### PR TITLE
simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,47 +23,29 @@ Split only supports redis 2.0 or greater.
 If you're on OS X, Homebrew is the simplest way to install Redis:
 
 ```bash
-$ brew install redis
-$ redis-server /usr/local/etc/redis.conf
+brew install redis
+redis-server /usr/local/etc/redis.conf
 ```
 
 You now have a Redis daemon running on 6379.
 
 ## Setup
 
-If you are using bundler add split to your Gemfile:
-
-``` ruby
-gem 'split'
-```
-
-Then run:
-
 ```bash
-$ bundle install
+gem install split
 ```
 
-Otherwise install the gem:
+### Rails
 
-```bash
-$ gem install split
-```
-
-and require it in your project:
-
-```ruby
-require 'split'
-```
-
-### Rails 3
-
-Split is autoloaded when rails starts up, as long as you've configured redis it will 'just work'.
+Adding `gem 'split'` to your Gemfile will autoloaded it when rails starts up, as long as you've configured redis it will 'just work'.
 
 ### Sinatra
 
 To configure sinatra with Split you need to enable sessions and mix in the helper methods. Add the following lines at the top of your sinatra app:
 
 ```ruby
+require 'split'
+
 class MySinatraApp < Sinatra::Base
   enable :sessions
   helpers Split::Helper


### PR DESCRIPTION
 - if you are on ruby 1.8 chances are you are not adding new fancy gems
 - same goes for rails 2.3
 - rails does not need the require
 - if you use bundler you most likely know howto add gems to it
 - make bash commands copy pasteable by removing the $

@andrew a few random fixes, let me know which ones you like :)

[Preview](https://github.com/grosser/split/blob/a44547e872ab4c1a866a7492641b00165280b28c/README.md)

