### PR TITLE
allow for custom redis_url different from ENV variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,10 +343,11 @@ Split.configure do |config|
   config.persistence = Split::Persistence::SessionAdapter
   #config.start_manually = false ## new test will have to be started manually from the admin panel. default false
   config.include_rails_helper = true
+  config.redis_url = "custom.redis.url:6380"
 end
 ```
 
-You can set different Redis host via environment variable ```REDIS_URL```.
+Split looks for the Redis host in the environment variable ```REDIS_URL``` then defaults to ```localhost:6379``` if not specified by configure block.
 
 ### Filtering
 

--- a/lib/split.rb
+++ b/lib/split.rb
@@ -53,7 +53,7 @@ module Split
   # create a new one.
   def redis
     return @redis if @redis
-    self.redis = ENV.fetch('REDIS_URL', 'localhost:6379')
+    self.redis = self.configuration.redis_url
     self.redis
   end
 

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -19,6 +19,7 @@ module Split
     attr_accessor :on_experiment_delete
     attr_accessor :include_rails_helper
     attr_accessor :beta_probability_simulations
+    attr_accessor :redis_url
 
     attr_reader :experiments
 
@@ -204,6 +205,7 @@ module Split
       @algorithm = Split::Algorithms::WeightedSample
       @include_rails_helper = true
       @beta_probability_simulations = 10000
+      @redis_url = ENV.fetch('REDIS_URL', 'localhost:6379')
     end
 
     private

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -210,4 +210,22 @@ describe Split::Configuration do
 
     expect(@config.normalized_experiments).to eq({:my_experiment=>{:alternatives=>[{"control_opt"=>0.67}, [{"second_opt"=>0.1}, {"third_opt"=>0.23}]]}})
   end
+
+  context "configuration URL" do
+    it "should default to local redis server" do
+      expect(@config.redis_url).to eq("localhost:6379")
+    end
+
+    it "should allow for redis url to be configured" do
+      @config.redis_url = "custom_redis_url"
+      expect(@config.redis_url).to eq("custom_redis_url")
+    end
+
+    context "provided REDIS_URL environment variable" do
+      it "should use the ENV variable" do
+        ENV['REDIS_URL'] = "env_redis_url"
+        expect(Split::Configuration.new.redis_url).to eq("env_redis_url")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Noticed that there was only a footnote on how to change the Redis url below configuration. I wrote the following changes and added in tests for the default behavior as well.

It wasn't until I was reviewing the `README.md` in preview mode to make sure the changes looked correct that I noticed the [Redis](https://github.com/splitrb/split#redis-1) section that talks about overwriting `Split.redis` directly.