### PR TITLE
Fix caching of winning alternative

### DIFF
--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -4,9 +4,7 @@
   <% experiment_class = "experiment" %>
 <% end %>
 
-<% unless experiment.calc_time == Time.now.day %>
-  <% experiment.estimate_winning_alternative %>
-<% end %>
+<% experiment.calc_winning_alternatives %>
 
 <div class="<%= experiment_class %>">
   <div class="experiment-header">

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -274,17 +274,22 @@ module Split
     end
 
     def calc_winning_alternatives
-      if goals.empty?
-        self.estimate_winning_alternative
-      else
-        goals.each do |goal|
-          self.estimate_winning_alternative(goal)
+      # Super simple cache so that we only recalculate winning alternatives once per day
+      days_since_epoch = Time.now.utc.to_i / 86400
+
+      if self.calc_time != days_since_epoch
+        if goals.empty?
+          self.estimate_winning_alternative
+        else
+          goals.each do |goal|
+            self.estimate_winning_alternative(goal)
+          end
         end
+
+        self.calc_time = days_since_epoch
+
+        self.save
       end
-
-      calc_time = Time.now.day
-
-      self.save
     end
 
     def estimate_winning_alternative(goal = nil)
@@ -390,7 +395,7 @@ module Split
     end
 
     def calc_time
-      Split.redis.hget(experiment_config_key, :calc_time)
+      Split.redis.hget(experiment_config_key, :calc_time).to_i
     end
 
     def jstring(goal = nil)

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -428,6 +428,13 @@ describe Split::Experiment do
       p_goal2 = alt.p_winner(goal2)
       expect(p_goal1).not_to be_within(0.04).of(p_goal2)
     end
+
+    it "should return nil and not re-calculate probabilities if they have already been calculated today" do
+      experiment = Split::ExperimentCatalog.find_or_create({'link_color3' => ["purchase", "refund"]}, 'blue', 'red', 'green')
+      experiment_calc_time = Time.now.utc.to_i / 86400
+      experiment.calc_time = experiment_calc_time
+      expect(experiment.calc_winning_alternatives).to be nil
+    end
   end
 
 end


### PR DESCRIPTION
It looks like when this feature was added the calculation of winning alternatives was meant to take place only once per day.

The `#calc_winning_alternatives` method was never called, which was meant to be saving the experiment's last `calc_time`.

Update the experiment view to call this method instead of the `#estimate_winning_alternative` method directly. Fix caching so that the `#calc_time=` metreturn value of hod is called, rather than assigning to a local variable. Update `calc_time` so that number of days since epoch is stored, rather than the day of month (1-31). Ensure we're comparing integer values, rather than the string value Redis returns from `#hget`.

It's worth noting that this pull request changes the value that `#calc_winning_alternatives` returns - it will now return `nil` if there was a cache was hit. Given nothing was previously calling this method I think that's probably ok. If not, we can refactor things a little to make it easier to return the cached value.

On a side note, I ran into this because our Split dashboard was too slow to load and was timing out on Heroku (30+ second request time with around 40 experiments). I'm not very across the statistical method for calculating the winning alternative - is it possible to speed this up at all, or reduce the number of iterations without compromising the result? It's a relatively expensive operation, and it would be nice to not have to cache the result.

/cc @caser 