### PR TITLE
fix active experiments when experiment is on a later version

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -116,9 +116,10 @@ module Split
     def active_experiments
       experiment_pairs = {}
       ab_user.keys.each do |key|
-        Metric.possible_experiments(key).each do |experiment|
+        key_without_version = key.split(/\:\d(?!\:)/)[0]
+        Metric.possible_experiments(key_without_version).each do |experiment|
           if !experiment.has_winner?
-            experiment_pairs[key] = ab_user[key]
+            experiment_pairs[key_without_version] = ab_user[key]
           end
         end
       end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -449,6 +449,14 @@ describe Split::Helper do
       expect(active_experiments.first[0]).to eq "def"
       expect(active_experiments.first[1]).to eq alternative
     end
+    
+    it 'should show an active test when an experiment is on a later version' do
+      experiment.reset
+      expect(experiment.version).to eq(1)
+      ab_test('link_color', 'blue', 'red')
+      expect(active_experiments.count).to eq 1
+      expect(active_experiments.first[0]).to eq "link_color"
+    end
 
     it 'should show multiple tests' do
       Split.configure do |config|


### PR DESCRIPTION
Fix to this issue: https://github.com/splitrb/split/issues/330