### PR TITLE
Cookie length config

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ Split.configure do |config|
 end
 ```
 
+By default, cookies will expire in 1 year. To change that, set the `persistence_cookie_length` in the configuration.
+
+```ruby
+Split.configure do |config|
+  config.persistence = :cookie
+  config.persistence_cookie_length = 2592000 # 30 days
+end
+```
+
 __Note:__ Using cookies depends on `ActionDispatch::Cookies` or any identical API
 
 #### Redis

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Split.configure do |config|
 end
 ```
 
-By default, cookies will expire in 1 year. To change that, set the `persistence_cookie_length` in the configuration.
+By default, cookies will expire in 1 year. To change that, set the `persistence_cookie_length` in the configuration (unit of time in seconds).
 
 ```ruby
 Split.configure do |config|

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -10,6 +10,7 @@ module Split
     attr_accessor :allow_multiple_experiments
     attr_accessor :enabled
     attr_accessor :persistence
+    attr_accessor :persistence_cookie_length
     attr_accessor :algorithm
     attr_accessor :store_override
     attr_accessor :start_manually
@@ -202,6 +203,7 @@ module Split
       @enabled = true
       @experiments = {}
       @persistence = Split::Persistence::SessionAdapter
+      @persistence_cookie_length = 31536000 # One year from now
       @algorithm = Split::Algorithms::WeightedSample
       @include_rails_helper = true
       @beta_probability_simulations = 10000

--- a/lib/split/persistence/cookie_adapter.rb
+++ b/lib/split/persistence/cookie_adapter.rb
@@ -4,10 +4,9 @@ module Split
   module Persistence
     class CookieAdapter
 
-      EXPIRES = Time.now + 31536000 # One year from now
-
       def initialize(context)
         @cookies = context.send(:cookies)
+        @expires = Time.now + cookie_length_config
       end
 
       def [](key)
@@ -31,7 +30,7 @@ module Split
       def set_cookie(value)
         @cookies[:split] = {
           :value => JSON.generate(value),
-          :expires => EXPIRES
+          :expires => @expires
         }
       end
 
@@ -45,6 +44,10 @@ module Split
         else
           {}
         end
+      end
+
+      def cookie_length_config
+        Split.configuration.persistence_cookie_length
       end
 
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -228,4 +228,16 @@ describe Split::Configuration do
       end
     end
   end
+
+  context "persistence cookie length" do
+    it "should default to 1 year" do
+      expect(@config.persistence_cookie_length).to eq(31536000)
+    end
+
+    it "should allow the persistence cookie length to be configured" do
+      @config.persistence_cookie_length = 2592000
+      expect(@config.persistence_cookie_length).to eq(2592000)
+    end
+  end
+
 end


### PR DESCRIPTION
This adds the ability to change the length of the persistence cookie to a time period other than 1 year.