### PR TITLE
Rescue from Redis::BaseError in #ab_test

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -16,7 +16,7 @@ module Split
         else
           control_variable(experiment.control)
         end
-      rescue Errno::ECONNREFUSED, Redis::CannotConnectError, SocketError => e
+      rescue Errno::ECONNREFUSED, Redis::BaseError, SocketError => e
         raise(e) unless Split.configuration.db_failover
         Split.configuration.db_failover_on_db_error.call(e)
 


### PR DESCRIPTION
Redis defines a number of different exception classes (see https://github.com/redis/redis-rb/blob/1bd43346cdf71ba69176612714616289a5a70ed4/lib/redis/errors.rb for details). When Redis raises an exception, we need to be able to have the db_failover configuration used, whether it's a failure to connect, a timeout, or an invalid command.

We ran into this issue when our Redis instance ran out of memory. In that case (and most others), Split should be able to handle things gracefully.