### PR TITLE
Fix the dashboard for experiments with ‘/‘ in the name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ end
   - [Split::Mongoid](https://github.com/MongoHQ/split-mongoid) - store experiment data in mongoid (still uses redis)
   - [Split::Cacheable](https://github.com/harrystech/split_cacheable) - automatically create cache buckets per test
   - [Split::Counters](https://github.com/bernardkroes/split-counters) - add counters per experiment and alternative
+  - [Split::Cli](https://github.com/craigmcnamara/split-cli) - a CLI to trigger Split A/B tests
 
 ## Screencast
 

--- a/lib/split/dashboard.rb
+++ b/lib/split/dashboard.rb
@@ -29,32 +29,32 @@ module Split
       erb :index
     end
 
-    post '/:experiment' do
+    post '/experiment' do
       @experiment = Split::ExperimentCatalog.find(params[:experiment])
       @alternative = Split::Alternative.new(params[:alternative], params[:experiment])
       @experiment.winner = @alternative.name
       redirect url('/')
     end
 
-    post '/start/:experiment' do
+    post '/start' do
       @experiment = Split::ExperimentCatalog.find(params[:experiment])
       @experiment.start
       redirect url('/')
     end
 
-    post '/reset/:experiment' do
+    post '/reset' do
       @experiment = Split::ExperimentCatalog.find(params[:experiment])
       @experiment.reset
       redirect url('/')
     end
 
-    post '/reopen/:experiment' do
+    post '/reopen' do
       @experiment = Split::ExperimentCatalog.find(params[:experiment])
       @experiment.reset_winner
       redirect url('/')
     end
 
-    delete '/:experiment' do
+    delete '/experiment' do
       @experiment = Split::ExperimentCatalog.find(params[:experiment])
       @experiment.delete
       redirect url('/')

--- a/lib/split/dashboard/views/_controls.erb
+++ b/lib/split/dashboard/views/_controls.erb
@@ -1,18 +1,18 @@
 <% if experiment.has_winner? %>
-  <form action="<%= url "/reopen/#{experiment.name}" %>" method='post' onclick="return confirmReopen()">
+  <form action="<%= url "/reopen?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReopen()">
     <input type="submit" value="Reopen Experiment">
   </form>
 <% end %>
 <% if experiment.start_time %>
-  <form action="<%= url "/reset/#{experiment.name}" %>" method='post' onclick="return confirmReset()">
+  <form action="<%= url "/reset?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReset()">
     <input type="submit" value="Reset Data">
   </form>
 <% else%>
-  <form action="<%= url "/start/#{experiment.name}" %>" method='post'>
+  <form action="<%= url "/start?experiment=#{experiment.name}" %>" method='post'>
     <input type="submit" value="Start">
   </form>
 <% end %>
-<form action="<%= url "/#{experiment.name}" %>" method='post' onclick="return confirmDelete()">
+<form action="<%= url "/?experiment=#{experiment.name}" %>" method='post' onclick="return confirmDelete()">
   <input type="hidden" name="_method" value="delete"/>
   <input type="submit" value="Delete" class="red">
 </form>

--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -95,7 +95,7 @@
               Loser
             <% end %>
           <% else %>
-            <form action="<%= url experiment.name %>" method='post' onclick="return confirmWinner()">
+            <form action="<%= url('experiment') + '?experiment=' + experiment.name %>" method='post' onclick="return confirmWinner()">
               <input type='hidden' name='alternative' value='<%= h alternative.name %>'>
               <input type="submit" value="Use this" class="green">
             </form>

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -400,7 +400,12 @@ module Split
     end
 
     def jstring(goal = nil)
-      (goal.nil? ? name : name + "-" + goal).gsub('/', '--')
+      js_id = if goal.nil?
+                name
+              else
+                name + "-" + goal
+              end
+      js_id.gsub('/', '--')
     end
 
     protected

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -400,11 +400,7 @@ module Split
     end
 
     def jstring(goal = nil)
-      unless goal.nil?
-        jstring = name + "-" + goal
-      else
-        jstring = name
-      end
+      (goal.nil? ? name : name + "-" + goal).gsub('/', '--')
     end
 
     protected

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -44,7 +44,7 @@ describe Split::Dashboard do
         get '/'
         expect(last_response.body).to include('Start')
 
-        post "/start/#{experiment.name}"
+        post "/start?experiment=#{experiment.name}"
         get '/'
         expect(last_response.body).to include('Reset Data')
         expect(last_response.body).not_to include('Metrics:')
@@ -65,7 +65,7 @@ describe Split::Dashboard do
         get '/'
         expect(last_response.body).to include('Start')
 
-        post "/start/#{experiment.name}"
+        post "/start?experiment=#{experiment.name}"
         get '/'
         expect(last_response.body).to include('Reset Data')
       end
@@ -96,13 +96,13 @@ describe Split::Dashboard do
     before { experiment.winner = 'red' }
 
     it 'redirects' do
-      post "/reopen/#{experiment.name}"
+      post "/reopen?experiment=#{experiment.name}"
 
       expect(last_response).to be_redirect
     end
 
     it "removes winner" do
-      post "/reopen/#{experiment.name}"
+      post "/reopen?experiment=#{experiment.name}"
 
       expect(experiment).to_not have_winner
     end
@@ -112,7 +112,7 @@ describe Split::Dashboard do
       blue_link.participant_count = 7
       experiment.winner = 'blue'
 
-      post "/reopen/#{experiment.name}"
+      post "/reopen?experiment=#{experiment.name}"
 
       expect(red_link.participant_count).to eq(5)
       expect(blue_link.participant_count).to eq(7)
@@ -124,7 +124,7 @@ describe Split::Dashboard do
     blue_link.participant_count = 7
     experiment.winner = 'blue'
 
-    post "/reset/#{experiment.name}"
+    post "/reset?experiment=#{experiment.name}"
 
     expect(last_response).to be_redirect
 
@@ -137,14 +137,14 @@ describe Split::Dashboard do
   end
 
   it "should delete an experiment" do
-    delete "/#{experiment.name}"
+    delete "/experiment?experiment=#{experiment.name}"
     expect(last_response).to be_redirect
     expect(Split::ExperimentCatalog.find(experiment.name)).to be_nil
   end
 
   it "should mark an alternative as the winner" do
     expect(experiment.winner).to be_nil
-    post "/#{experiment.name}", :alternative => 'red'
+    post "/experiment?experiment=#{experiment.name}", :alternative => 'red'
 
     expect(last_response).to be_redirect
     expect(experiment.winner.name).to eq('red')


### PR DESCRIPTION
I've got a fairly complex split install. Some experiments have names like url path segments and and ‘/‘ messes up the dashboard JS and sinatra routing when one of those names is used as a pretty url parameter, even though it's a valid experiment name for the rest of split.

This makes minor changes to the routing for the `post` and `delete` routing and updates the HTML to pass the experiment name as a query string.