### PR TITLE
Implement filtering dashboard by active/complete experiments

### DIFF
--- a/lib/split/dashboard/public/dashboard-filtering.js
+++ b/lib/split/dashboard/public/dashboard-filtering.js
@@ -15,5 +15,29 @@ $(function() {
   $('#clear-filter').on('click', function() {
     $('#filter').val('');
     $('div.experiment').show();
+    $('#toggle-active').val('Hide active');
+    $('#toggle-completed').val('Hide completed');
+  });
+
+  $('#toggle-active').on('click', function() {
+    $button = $(this);
+    if ($button.val() == 'Hide active') {
+      $button.val('Show active');
+    } else {
+      $button.val('Hide active');
+    }
+
+    $('div.experiment[data-complete="false"]').toggle();
+  });
+
+  $('#toggle-completed').on('click', function() {
+    $button = $(this);
+    if ($button.val() == 'Hide completed') {
+      $button.val('Show completed');
+    } else {
+      $button.val('Hide completed');
+    }
+
+    $('div.experiment[data-complete="true"]').toggle();
   });
 });

--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -6,7 +6,7 @@
 
 <% experiment.calc_winning_alternatives %>
 
-<div class="<%= experiment_class %>" data-name="<%= experiment.name %>">
+<div class="<%= experiment_class %>" data-name="<%= experiment.name %>" data-complete="<%= experiment.has_winner? %>">
   <div class="experiment-header">
     <h2>
       Experiment: <%= experiment.name %>

--- a/lib/split/dashboard/views/index.erb
+++ b/lib/split/dashboard/views/index.erb
@@ -2,7 +2,9 @@
   <p class="intro">The list below contains all the registered experiments along with the number of test participants, completed and conversion rate currently in the system.</p>
 
   <input type="text" placeholder="Begin typing to filter" id="filter" />
-  <input type="button" id="clear-filter" value="Clear filter" />
+  <input type="button" id="toggle-completed" value="Hide completed" />
+  <input type="button" id="toggle-active" value="Hide active" />
+  <input type="button" id="clear-filter" value="Clear filters" />
 
   <% @experiments.each do |experiment| %>
     <% if experiment.goals.empty? %>


### PR DESCRIPTION
This is a follow-up to #363. It adds the ability to toggle between active/completed experiments at the top, with the "Clear filters" button resetting the page state. It's a really simple implementation but provides some helpful functionality.

Let me know if you'd like to see any changes.