### PR TITLE
respect manual start configuration  after an experiment has been deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ It is not required to send `SPLIT_DISABLE=false` to activate Split.
 By default new AB tests will be active right after deployment. In case you would like to start new test a while after
 the deploy, you can do it by setting the `start_manually` configuration option to `true`.
 
-After choosing this option tests won't be started right after deploy, but after pressing the `Start` button in Split admin dashboard.
+After choosing this option tests won't be started right after deploy, but after pressing the `Start` button in Split admin dashboard.  If a test is deleted from the Split dashboard, then it can only be started after pressing the `Start` button whenever being re-initialized.
 
 ### Reset after completion
 

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -248,6 +248,9 @@ module Split
 
     def delete
       Split.configuration.on_before_experiment_delete.call(self)
+      if Split.configuration.start_manually
+        Split.redis.hdel(:experiment_start_times, @name)
+      end
       alternatives.each(&:delete)
       reset_winner
       Split.redis.srem(:experiments, name)

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -203,6 +203,13 @@ describe Split::Experiment do
       expect(Split.configuration.on_before_experiment_delete).to receive(:call)
       experiment.delete
     end
+
+    it 'should reset the start time if the experiment should be manually started' do
+      Split.configuration.start_manually = true
+      experiment.start
+      experiment.delete
+      expect(experiment.start_time).to be_nil
+    end
   end
 
 


### PR DESCRIPTION
When Split is configured to start experiments manually, deleted experiments will be re-initialized and immediately active unless there is a re-deployment with `ab_test` code for that experiment removed.  This change ensures that Split respects the `start_manually` configuration for this case without requiring code cleanup and re-deployment.