### PR TITLE
Allow algorithm configuration at experiment level

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -151,6 +151,10 @@ module Split
             experiment_config[experiment_name.to_sym][:metadata] = metadata
           end
 
+          if algorithm = value_for(settings, :algorithm)
+            experiment_config[experiment_name.to_sym][:algorithm] = algorithm
+          end
+
           if (resettable = value_for(settings, :resettable)) != nil
             experiment_config[experiment_name.to_sym][:resettable] = resettable
           end


### PR DESCRIPTION
**What was missing**
* While reading the configurations for experiments, `algorithm` key was ignored. In-fact other configuration_keys like `resettable`, `goals`, `alternatives` were being considered.

**What is implemented in this PR**
* While reading all configurations at `../lib/configuration.rb` (forex: by function `Split.configuration.experiment_for(@name)` ), `algorithm` key was taken into account along with other config_keys

**Related Issue**
https://github.com/splitrb/split/issues/344