### PR TITLE
increment participation if store override is true and no experiment key exists

### DIFF
--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -55,6 +55,9 @@ module Split
 
       if override_is_alternative?
         self.alternative = @options[:override]
+        if should_store_alternative? && !@user[@experiment.key]
+          self.alternative.increment_participation
+        end
       elsif @options[:disabled] || Split.configuration.disabled?
         self.alternative = @experiment.control
       elsif @experiment.has_winner?

--- a/spec/trial_spec.rb
+++ b/spec/trial_spec.rb
@@ -239,6 +239,7 @@ describe Split::Trial do
         Split.configuration.store_override = true
         expect(user).to receive("[]=")
         trial.choose!
+        expect(trial.alternative.participant_count).to eq(1)
       end
 
       it "does not store when store_override is false" do


### PR DESCRIPTION
Storing the override wouldn't increment participant count but would 'finish' an experiment