### PR TITLE
Remove unecessary code from Experiment#save

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -86,7 +86,6 @@ module Split
         @alternatives.reverse.each {|a| Split.redis.lpush(name, a.name)}
         goals_collection.save
         save_metadata
-        Split.redis.set(metadata_key, @metadata.to_json) unless @metadata.nil?
       else
         existing_alternatives = load_alternatives_from_redis
         existing_goals = Split::GoalsCollection.new(@name).load_from_redis


### PR DESCRIPTION
Experiment#save_metadata is called in the previous line, which
resulted in calling `Split.redis.set(metadata_key, @metadata.to_json)`
twice. I removed the unecessary line.