### PR TITLE
DRY Experiment#initialize

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -21,22 +21,18 @@ module Split
       alternatives = extract_alternatives_from_options(options)
 
       if alternatives.empty? && (exp_config = Split.configuration.experiment_for(name))
-        set_alternatives_and_options(
+        options = {
           alternatives: load_alternatives_from_configuration,
           goals: Split::GoalsCollection.new(@name).load_from_configuration,
           metadata: load_metadata_from_configuration,
           resettable: exp_config[:resettable],
           algorithm: exp_config[:algorithm]
-        )
+        }
       else
-        set_alternatives_and_options(
-          alternatives: alternatives,
-          goals: options[:goals],
-          metadata: options[:metadata],
-          resettable: options[:resettable],
-          algorithm: options[:algorithm]
-        )
+        options[:alternatives] = alternatives
       end
+
+      set_alternatives_and_options(options)
     end
 
     def set_alternatives_and_options(options)


### PR DESCRIPTION
Experiment#set_alternatives_and_options appeared both in the `if`
section and in the `else` section. I moved `set_alternatives_and_options`
out of the `if...else` block so that it is more DRY.

I am not sure if setting only options[:alternatives] in the `else`
clause is more readable than explicitly providing a hash with the attributes
to set as it happens in the `if` clause.