### PR TITLE
Namespaced override param

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You can do this by passing it as a parameter in the url.
 
 If you have an experiment called `button_color` with alternatives called `red` and `blue` used on your homepage, a url such as:
 
-    http://myawesomesite.com?button_color=red
+    http://myawesomesite.com?ab_test[button_color]=red
 
 will always have red buttons. This won't be stored in your session or count towards to results, unless you set the `store_override` configuration option.
 

--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Split
   module Helper
+    OVERRIDE_PARAM_NAME = "ab_test"
+
     module_function
 
     def ab_test(metric_descriptor, control = nil, *alternatives)
@@ -80,11 +82,11 @@ module Split
     end
 
     def override_present?(experiment_name)
-      defined?(params) && params[experiment_name]
+      override_alternative(experiment_name)
     end
 
     def override_alternative(experiment_name)
-      params[experiment_name] if override_present?(experiment_name)
+      defined?(params) && params[OVERRIDE_PARAM_NAME] && params[OVERRIDE_PARAM_NAME][experiment_name]
     end
 
     def split_generically_disabled?

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -89,27 +89,33 @@ describe Split::Helper do
       expect(ab_test('link_color', 'blue', 'red')).to eq('orange')
     end
 
-    it "should allow the alternative to be force by passing it in the params" do
-      @params = {'link_color' => 'blue'}
+    it "should allow the alternative to be forced by passing it in the params" do
+      # ?ab_test[link_color]=blue
+      @params = { 'ab_test' => { 'link_color' => 'blue' } }
+
       alternative = ab_test('link_color', 'blue', 'red')
       expect(alternative).to eq('blue')
+
       alternative = ab_test('link_color', {'blue' => 1}, 'red' => 5)
       expect(alternative).to eq('blue')
-      @params = {'link_color' => 'red'}
+
+      @params = { 'ab_test' => { 'link_color' => 'red' } }
+
       alternative = ab_test('link_color', 'blue', 'red')
       expect(alternative).to eq('red')
+
       alternative = ab_test('link_color', {'blue' => 5}, 'red' => 1)
       expect(alternative).to eq('red')
     end
 
     it "should not allow an arbitrary alternative" do
-      @params = {'link_color' => 'pink'}
+      @params = { 'ab_test' => { 'link_color' => 'pink' } }
       alternative = ab_test('link_color', 'blue')
       expect(alternative).to eq('blue')
     end
 
     it "should not store the split when a param forced alternative" do
-      @params = {'link_color' => 'blue'}
+      @params = { 'ab_test' => { 'link_color' => 'blue' } }
       expect(ab_user).not_to receive(:[]=)
       ab_test('link_color', 'blue', 'red')
     end
@@ -136,7 +142,7 @@ describe Split::Helper do
       before { Split.configuration.store_override = true }
 
       it "should store the forced alternative" do
-        @params = {'link_color' => 'blue'}
+        @params = { 'ab_test' => { 'link_color' => 'blue' } }
         expect(ab_user).to receive(:[]=).with('link_color', 'blue')
         ab_test('link_color', 'blue', 'red')
       end
@@ -212,7 +218,7 @@ describe Split::Helper do
     end
 
     it 'should be passed to helper block' do
-      @params = {'my_experiment' => 'one'}
+      @params = { 'ab_test' => { 'my_experiment' => 'one' } }
       expect(ab_test('my_experiment')).to eq 'one'
       expect(ab_test('my_experiment') do |alternative, meta|
         meta
@@ -770,7 +776,7 @@ describe Split::Helper do
 
           context 'and given an override parameter' do
             it 'should use given override instead of the first alternative' do
-              @params = {'link_color' => 'red'}
+              @params = { 'ab_test' => { 'link_color' => 'red' } }
               expect(ab_test('link_color', 'blue', 'red')).to eq('red')
               expect(ab_test('link_color', 'blue', 'red', 'green')).to eq('red')
               expect(ab_test('link_color', {'blue' => 0.01}, 'red' => 0.2)).to eq('red')


### PR DESCRIPTION
As discussed in #381.

Verified that both Rails and Sinatra parse [] in params to nested hashes this way.

Per #396, maybe "split_test" would be a better namespace?