### PR TITLE
FIX Negative numbers on non-finished

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -35,6 +35,10 @@ module Split
       set_alternatives_and_options(options)
     end
 
+    def self.finished_key(key)
+      "#{key}:finished"
+    end
+
     def set_alternatives_and_options(options)
       self.alternatives = options[:alternatives]
       self.goals = options[:goals]
@@ -221,7 +225,7 @@ module Split
     end
 
     def finished_key
-      "#{key}:finished"
+      self.class.finished_key(key)
     end
 
     def metadata_key

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -9,10 +9,11 @@ module Split
     end
 
     def cleanup_old_experiments!
-      user.keys.each do |key|
+      keys_without_finished(user.keys).each do |key|
         experiment = ExperimentCatalog.find key_without_version(key)
         if experiment.nil? || experiment.has_winner? || experiment.start_time.nil?
           user.delete key
+          user.delete Experiment.finished_key(key)
         end
       end
     end
@@ -43,6 +44,10 @@ module Split
 
     def keys_without_experiment(keys, experiment_key)
       keys.reject { |k| k.match(Regexp.new("^#{experiment_key}(:finished)?$")) }
+    end
+
+    def keys_without_finished(keys)
+      keys.reject { |k| k.include?(":finished") }
     end
 
     def key_without_version(key)

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -44,6 +44,20 @@ describe Split::User do
       allow(experiment).to receive(:has_winner?).and_return(false)
       @subject.cleanup_old_experiments!
       expect(@subject.keys).to be_empty
-    end    
+    end
+
+    context 'with finished key' do
+      let(:user_keys) { { 'link_color' => 'blue', 'link_color:finished' => true } }
+
+      it 'does not remove finished key for experiment without a winner' do
+        allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
+        allow(Split::ExperimentCatalog).to receive(:find).with('link_color:finished').and_return(nil)
+        allow(experiment).to receive(:start_time).and_return(Date.today)
+        allow(experiment).to receive(:has_winner?).and_return(false)
+        @subject.cleanup_old_experiments!
+        expect(@subject.keys).to include("link_color")
+        expect(@subject.keys).to include("link_color:finished")
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes a major bug when negative non-finished numbers appear and simple random exception fired on the dashboard. Actually, without this fix all experiments which are finished with "reset: false" produce invalid results.

The problem was with User#cleanup_old_experiments! method because it treats “experimen1:finished” key as a non-found experiment and just deletes it.

Related issues:

https://github.com/splitrb/split/issues/43

https://github.com/splitrb/split/issues/103

https://github.com/splitrb/split/issues/133

https://github.com/splitrb/split/issues/355

https://github.com/splitrb/split/issues/294

https://github.com/splitrb/split/issues/272