### PR TITLE
Add `expire_seconds:` TTL option to RedisAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ end
 Options:
 * `lookup_by`: method to invoke per request for uniquely identifying ab_users (mandatory configuration)
 * `namespace`: separate namespace to store these persisted values (default "persistence")
+* `expire_seconds`: sets TTL for user key. (if a user is in multiple experiments most recent update will reset TTL for all their assignments)
 
 #### Custom Adapter
 

--- a/lib/split/persistence/redis_adapter.rb
+++ b/lib/split/persistence/redis_adapter.rb
@@ -27,6 +27,8 @@ module Split
 
       def []=(field, value)
         Split.redis.hset(redis_key, field, value)
+        expire_seconds = self.class.config[:expire_seconds]
+        Split.redis.expire(redis_key, expire_seconds) if expire_seconds
       end
 
       def delete(field)


### PR DESCRIPTION
Issue #403 Support TTL for participants in RedisAdapter