### PR TITLE
Optional custom persistence adapter

### DIFF
--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -4,8 +4,8 @@ module Split
     def_delegators :@user, :keys, :[], :[]=, :delete
     attr_reader :user
 
-    def initialize(context)
-      @user = Split::Persistence.adapter.new(context)
+    def initialize(context, adapter=nil)
+      @user = adapter || Split::Persistence.adapter.new(context)
     end
 
     def cleanup_old_experiments!

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -60,4 +60,17 @@ describe Split::User do
       end
     end
   end
+
+  context "instantiated with custom adapter" do
+    let(:custom_adapter) { double(:persistence_adapter) }
+
+    before do
+      @subject = described_class.new(context, custom_adapter)
+    end
+
+    it "sets user to the custom adapter" do
+      expect(@subject.user).to eq(custom_adapter)
+    end
+  end
+
 end


### PR DESCRIPTION
Update `Split::User` to accept an optional persistence adapter, overriding the default.

This allows for running experiments outside a web request that are tied to a particular "user". By making use of `Split::User` when running the experiment, you're able to initiate the experiment one day and record a completion at a later time (by retrieving the earlier trial).

**Running an experiment**
```ruby
experiment_name = :welcome_message

key = "thing-#{thing.id}"
# since we're outside the context of a web request, the first arg `context` is nil
ab_user = Split::User.new(Split::Persistence.adapter.new(nil, key)
experiment = Split::ExperimentCatalog.find_or_create(experiment_name)
trial = Split::Trial.new(user: ab_user, experiment: experiment)
trial.choose!

if trial.alternative.name == "short_message"
  send_short_message
elsif trial.alternative.name == "long_message"
  send_long_message
end
```

**Recording completion at later date**
```ruby
experiment_name = :welcome_message

if conversion?
  # using the same key to retrieve our earlier trial
  key = "thing-#{thing.id}"
  ab_user = Split::User.new(Split::Persistence.adapter.new(nil, key)
  experiment = Split::ExperimentCatalog.find_or_create(experiment_name)
  trial = Split::Trial.new(user: ab_user, experiment: experiment)

  trial.complete!
end
```

Fixes #410 
