### PR TITLE
Issue #405 Running concurrent experiments on same endpoint/view

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,13 +171,24 @@ Any old unfinished experiment key will be deleted from the user's data storage i
 
 By default Split will avoid users participating in multiple experiments at once. This means you are less likely to skew results by adding in more variation to your tests.
 
-To stop this behaviour and allow users to participate in multiple experiments at once enable the `allow_multiple_experiments` config option like so:
+To stop this behaviour and allow users to participate in multiple experiments at once set the `allow_multiple_experiments` config option to true like so:
 
 ```ruby
 Split.configure do |config|
   config.allow_multiple_experiments = true
 end
 ```
+
+This will allow the user to participate in any number of experiments and belong to any alternative in each experiment. This has the possible downside of a variation in one experiment influencing the outcome of another.
+
+To address this, setting the `allow_multiple_experiments` config option to 'control' like so:
+```ruby
+Split.configure do |config|
+  config.allow_multiple_experiments = 'control'
+end
+```
+
+For this to work, each and every experiment you define must have an alternative named 'control'. This will allow the user to participate in multiple experiments as long as the user belongs to the alternative 'control' in each experiment. As soon as the user belongs to an alternative named something other than 'control' the user may not participate in any more experiments. Calling ab_test(<other experiments>) will always return the first alternative without adding the user to that experiment.
 
 ### Experiment Persistence
 

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -19,8 +19,14 @@ module Split
     end
 
     def max_experiments_reached?(experiment_key)
-      !Split.configuration.allow_multiple_experiments &&
-        keys_without_experiment(user.keys, experiment_key).length > 0
+      if Split.configuration.allow_multiple_experiments == 'control'
+        experiments = active_experiments
+        count_control = experiments.values.count {|v| v == 'control'}
+        experiments.size > count_control
+      else
+        !Split.configuration.allow_multiple_experiments &&
+          keys_without_experiment(user.keys, experiment_key).length > 0
+      end
     end
 
     def cleanup_old_versions!(experiment)

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -191,6 +191,26 @@ describe Split::Helper do
       expect(button_size_alt.participant_count).to eq(1)
     end
 
+    it "should let a user participate in many experiment with one non-'control' alternative with allow_multiple_experiments = 'control'" do
+      Split.configure do |config|
+        config.allow_multiple_experiments = 'control'
+      end
+      groups = []
+      (0..100).each do |n|
+        alt = ab_test("test#{n}".to_sym, {'control' => (100 - n)}, {'test#{n}-alt' => n})
+        groups << alt
+      end
+
+      experiments = ab_user.active_experiments
+      expect(experiments.size).to be > 1
+
+      count_control = experiments.values.count { |g| g == 'control' }
+      expect(count_control).to eq(experiments.size - 1)
+
+      count_alts = groups.count { |g| g != 'control' }
+      expect(count_alts).to eq(1)
+    end
+
     it "should not over-write a finished key when an experiment is on a later version" do
       experiment.increment_version
       ab_user = { experiment.key => 'blue', experiment.finished_key => true }


### PR DESCRIPTION
use config.allow_multiple_experiments = 'control' for multiple experiments per user with at most 1-non-control