### PR TITLE
Support REDIS_PROVIDER variable used in Heroku

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -211,7 +211,7 @@ module Split
       @algorithm = Split::Algorithms::WeightedSample
       @include_rails_helper = true
       @beta_probability_simulations = 10000
-      @redis_url = ENV.fetch('REDIS_URL', 'localhost:6379')
+      @redis_url = ENV.fetch(ENV.fetch('REDIS_PROVIDER', 'REDIS_URL'), 'localhost:6379')
     end
 
     private


### PR DESCRIPTION
Heroku Redis services often use the REDIS_PROVIDER variable to set the name of the variable which contains the Redis URL I'm using `config.redis_url` option but I think we should add support for REDIS_PROVIDER so Split works with minimal configuration.

As you can see Sidekiq also supports it: 
https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/redis_connection.rb#L93
```
def determine_redis_provider
  ENV[ENV['REDIS_PROVIDER'] || 'REDIS_URL']
end
```

In this pull request I've followed that method but used ENV.fetch as that was what was used before.