### PR TITLE
Remove dependency on Redis::Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,11 +469,11 @@ Split.configure do |config|
   config.persistence = Split::Persistence::SessionAdapter
   #config.start_manually = false ## new test will have to be started manually from the admin panel. default false
   config.include_rails_helper = true
-  config.redis_url = "custom.redis.url:6380"
+  config.redis = "redis://custom.redis.url:6380"
 end
 ```
 
-Split looks for the Redis host in the environment variable ```REDIS_URL``` then defaults to ```localhost:6379``` if not specified by configure block.
+Split looks for the Redis host in the environment variable `REDIS_URL` then defaults to `redis://localhost:6379` if not specified by configure block.
 
 ### Filtering
 

--- a/lib/split.rb
+++ b/lib/split.rb
@@ -56,7 +56,7 @@ module Split
   # create a new one.
   def redis
     return @redis if @redis
-    self.redis = self.configuration.redis_url
+    self.redis = self.configuration.redis
     self.redis
   end
 

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -214,6 +214,16 @@ module Split
       @redis = ENV.fetch(ENV.fetch('REDIS_PROVIDER', 'REDIS_URL'), 'redis://localhost:6379')
     end
 
+    def redis_url=(value)
+      warn '[DEPRECATED] `redis_url=` is deprecated in favor of `redis=`'
+      self.redis = value
+    end
+
+    def redis_url
+      warn '[DEPRECATED] `redis_url` is deprecated in favor of `redis`'
+      self.redis
+    end
+
     private
 
     def value_for(hash, key)

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -24,7 +24,7 @@ module Split
     attr_accessor :on_before_experiment_delete
     attr_accessor :include_rails_helper
     attr_accessor :beta_probability_simulations
-    attr_accessor :redis_url
+    attr_accessor :redis
 
     attr_reader :experiments
 
@@ -211,7 +211,7 @@ module Split
       @algorithm = Split::Algorithms::WeightedSample
       @include_rails_helper = true
       @beta_probability_simulations = 10000
-      @redis_url = ENV.fetch(ENV.fetch('REDIS_PROVIDER', 'REDIS_URL'), 'localhost:6379')
+      @redis = ENV.fetch(ENV.fetch('REDIS_PROVIDER', 'REDIS_URL'), 'redis://localhost:6379')
     end
 
     private

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -212,20 +212,20 @@ describe Split::Configuration do
     expect(@config.normalized_experiments).to eq({:my_experiment=>{:alternatives=>[{"control_opt"=>0.67}, [{"second_opt"=>0.1}, {"third_opt"=>0.23}]]}})
   end
 
-  context "configuration URL" do
+  context "redis configuration" do
     it "should default to local redis server" do
-      expect(@config.redis_url).to eq("localhost:6379")
+      expect(@config.redis).to eq("redis://localhost:6379")
     end
 
     it "should allow for redis url to be configured" do
-      @config.redis_url = "custom_redis_url"
-      expect(@config.redis_url).to eq("custom_redis_url")
+      @config.redis = "custom_redis_url"
+      expect(@config.redis).to eq("custom_redis_url")
     end
 
     context "provided REDIS_URL environment variable" do
       it "should use the ENV variable" do
         ENV['REDIS_URL'] = "env_redis_url"
-        expect(Split::Configuration.new.redis_url).to eq("env_redis_url")
+        expect(Split::Configuration.new.redis).to eq("env_redis_url")
       end
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -212,6 +212,20 @@ describe Split::Configuration do
     expect(@config.normalized_experiments).to eq({:my_experiment=>{:alternatives=>[{"control_opt"=>0.67}, [{"second_opt"=>0.1}, {"third_opt"=>0.23}]]}})
   end
 
+  context 'redis_url configuration [DEPRECATED]' do
+    it 'should warn on set and assign to #redis' do
+      expect(@config).to receive(:warn).with(/\[DEPRECATED\]/) { nil }
+      @config.redis_url = 'example_url'
+      expect(@config.redis).to eq('example_url')
+    end
+
+    it 'should warn on get and return #redis' do
+      expect(@config).to receive(:warn).with(/\[DEPRECATED\]/) { nil }
+      @config.redis = 'example_url'
+      expect(@config.redis_url).to eq('example_url')
+    end
+  end
+
   context "redis configuration" do
     it "should default to local redis server" do
       expect(@config.redis).to eq("redis://localhost:6379")

--- a/spec/split_spec.rb
+++ b/spec/split_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Split do
+
+  around(:each) do |ex|
+    old_env, old_redis = [ENV.delete('REDIS_URL'), Split.redis]
+    ex.run
+    ENV['REDIS_URL'] = old_env
+    Split.redis = old_redis
+  end
+
+  describe '#redis=' do
+    it 'accepts a url string' do
+      Split.redis = 'redis://localhost:6379'
+      expect(Split.redis).to be_a(Redis)
+
+      client = Split.redis.client
+      expect(client.host).to eq("localhost")
+      expect(client.port).to eq(6379)
+    end
+
+    it 'accepts an options hash' do
+      Split.redis = {host: 'localhost', port: 6379, db: 12}
+      expect(Split.redis).to be_a(Redis)
+
+      client = Split.redis.client
+      expect(client.host).to eq("localhost")
+      expect(client.port).to eq(6379)
+      expect(client.db).to eq(12)
+    end
+
+    it 'accepts a valid Redis instance' do
+      other_redis = Redis.new(url: "redis://localhost:6379")
+      Split.redis = other_redis
+      expect(Split.redis).to eq(other_redis)
+    end
+
+    it 'raises an ArgumentError when server cannot be determined' do
+      expect { Split.redis = Object.new }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/split.gemspec
+++ b/split.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'redis',           '>= 2.1'
-  s.add_dependency 'redis-namespace', '>= 1.1.0'
   s.add_dependency 'sinatra',         '>= 1.2.6'
   s.add_dependency 'simple-random',   '>= 0.9.3'
 


### PR DESCRIPTION
I was just wondering how open everyone would be to a future version removing the dependency on `redis-namespace`.

It seems like the [`Split.redis=`][method] is basically just doing some magic that accepts either:

* A url (either from `ENV['REDIS_URL']` or one supplied during configuration),
* a `Redis` instance, which is then namespaced automatically, or
* a `Redis::Namespace` instance.

Right now, the URL doesn't necessarily need to adhere to the [spec][redis-url]. I would be happy to work on a solution that simplifies the assignment to allow either:

1. A string as a [fully-qualified redis URL][redis-url]. This would still default to `ENV['REDIS_URL']` and would be passed as `{url: self.configuration.redis_url}` to `Redis.new`.
2. A hash passed directly to `Redis.new`.
3. Otherwise assume a user supplied `Redis` instance. If the user wants to use `Redis::Namespace`, adding that dependency and supplying that connection would be up to them.

Any thoughts? I know removing the dependency would break default installations, but the upgrade path would be as simple as adding `redis-namespace` and supplying that to the redis assignment.

[method]: https://github.com/splitrb/split/blob/v2.0.0/lib/split.rb#L35-L53
[redis-url]: https://github.com/ddollar/redis-url#url-format

