### PR TITLE
Make resetting on experiment change optional

### DIFF
--- a/lib/split.rb
+++ b/lib/split.rb
@@ -11,6 +11,7 @@
    metric
    persistence
    encapsulated_helper
+   redis_interface
    trial
    user
    version

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -15,6 +15,7 @@ module Split
     attr_accessor :algorithm
     attr_accessor :store_override
     attr_accessor :start_manually
+    attr_accessor :reset_manually
     attr_accessor :on_trial
     attr_accessor :on_trial_choose
     attr_accessor :on_trial_complete

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -441,10 +441,15 @@ module Split
       Split.redis
     end
 
+    def redis_interface
+      RedisInterface.new
+    end
+
     def persist_experiment_configuration
       remove_experiment_configuration unless new_record?
       redis.sadd(:experiments, name) unless redis.sismember(:experiments, name)
-      @alternatives.reverse.each { |a| redis.lpush(name, a.name) }
+      alternative_names = @alternatives.map(&:name)
+      redis_interface.persist_list(name, alternative_names)
       goals_collection.save
       save_metadata
     end

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -82,7 +82,7 @@ module Split
       if new_record?
         start unless Split.configuration.start_manually
       elsif experiment_configuration_has_changed?
-        reset
+        reset unless Split.configuration.reset_manually
       end
 
       persist_experiment_configuration if new_record? || experiment_configuration_has_changed?

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -9,7 +9,9 @@ module Split
     attr_accessor :alternative_probabilities
     attr_accessor :metadata
 
-    DEFAULT_OPTIONS = { resettable: true }.freeze
+    DEFAULT_OPTIONS = {
+      :resettable => true
+    }
 
     def initialize(name, options = {})
       options = DEFAULT_OPTIONS.merge(options)
@@ -49,9 +51,8 @@ module Split
       alts = options[:alternatives] || []
 
       if alts.length == 1
-        first_alternative = alts[0]
-        if first_alternative.is_a? Hash
-          alts = first_alternative.map { |key, value| { key => value } }
+        if alts[0].is_a? Hash
+          alts = alts[0].map{|k,v| {k => v} }
         end
       end
 
@@ -93,9 +94,9 @@ module Split
 
     def validate!
       if @alternatives.empty? && Split.configuration.experiment_for(@name).nil?
-        raise ExperimentNotFound, "Experiment #{@name} not found"
+        raise ExperimentNotFound.new("Experiment #{@name} not found")
       end
-      @alternatives.each(&:validate!)
+      @alternatives.each {|a| a.validate! }
       goals_collection.validate!
     end
 
@@ -103,12 +104,12 @@ module Split
       !redis.exists(name)
     end
 
-    def ==(other)
-      name == other.name
+    def ==(obj)
+      self.name == obj.name
     end
 
     def [](name)
-      alternatives.find { |alternative| alternative.name == name }
+      alternatives.find{|a| a.name == name}
     end
 
     def algorithm
@@ -134,9 +135,10 @@ module Split
     end
 
     def winner
-      experiment_winner = redis.hget(:experiment_winner, name)
-      unless experiment_winner.nil?
-        Split::Alternative.new(experiment_winner, name)
+      if w = redis.hget(:experiment_winner, name)
+        Split::Alternative.new(w, name)
+      else
+        nil
       end
     end
 
@@ -149,7 +151,7 @@ module Split
     end
 
     def participant_count
-      alternatives.inject(0) { |a, e| a + e.participant_count }
+      alternatives.inject(0){|sum,a| sum + a.participant_count}
     end
 
     def control
@@ -165,11 +167,14 @@ module Split
     end
 
     def start_time
-      time = redis.hget(:experiment_start_times, @name)
-      unless time.nil?
+      t = redis.hget(:experiment_start_times, @name)
+      if t
         # Check if stored time is an integer
-        return Time.at(time.to_i) if time =~ /^[-+]?[0-9]+$/
-        return Time.parse(time)
+        if t =~ /^[-+]?[0-9]+$/
+          t = Time.at(t.to_i)
+        else
+          t = Time.parse(t)
+        end
       end
     end
 
@@ -186,7 +191,7 @@ module Split
     end
 
     def version
-      @version ||= (redis.get("#{name}:version").to_i || 0)
+      @version ||= (redis.get("#{name.to_s}:version").to_i || 0)
     end
 
     def increment_version
@@ -226,14 +231,19 @@ module Split
     end
 
     def delete
-      split_configuration = Split.configuration
-      split_configuration.on_before_experiment_delete.call(self)
-      redis.hdel(:experiment_start_times, @name) if split_configuration.start_manually
+      Split.configuration.on_before_experiment_delete.call(self)
+      if Split.configuration.start_manually
+        redis.hdel(:experiment_start_times, @name)
+      end
       reset_winner
       redis.srem(:experiments, name)
       remove_experiment_configuration
-      split_configuration.on_experiment_delete.call(self)
+      Split.configuration.on_experiment_delete.call(self)
       increment_version
+    end
+
+    def delete_metadata
+      redis.del(metadata_key)
     end
 
     def load_from_redis
@@ -252,25 +262,25 @@ module Split
 
     def calc_winning_alternatives
       # Super simple cache so that we only recalculate winning alternatives once per day
-      days_since_epoch = Time.now.utc.to_i / 86_400
+      days_since_epoch = Time.now.utc.to_i / 86400
 
-      if calc_time != days_since_epoch
+      if self.calc_time != days_since_epoch
         if goals.empty?
-          estimate_winning_alternative
+          self.estimate_winning_alternative
         else
           goals.each do |goal|
-            estimate_winning_alternative(goal)
+            self.estimate_winning_alternative(goal)
           end
         end
 
         self.calc_time = days_since_epoch
 
-        save
+        self.save
       end
     end
 
     def estimate_winning_alternative(goal = nil)
-      # TODO: refactor out functionality to work with and without goals
+      # TODO - refactor out functionality to work with and without goals
 
       # initialize a hash of beta distributions based on the alternatives' conversion rates
       beta_params = calc_beta_params(goal)
@@ -293,7 +303,7 @@ module Split
 
       write_to_alternatives(goal)
 
-      save
+      self.save
     end
 
     def write_to_alternatives(goal = nil)
@@ -307,11 +317,11 @@ module Split
       winning_counts.each do |alternative, wins|
         alternative_probabilities[alternative] = wins / number_of_simulations.to_f
       end
-      alternative_probabilities
+      return alternative_probabilities
     end
 
     def count_simulated_wins(winning_alternatives)
-      # initialize a hash to keep track of winning alternative in simulations
+       # initialize a hash to keep track of winning alternative in simulations
       winning_counts = {}
       alternatives.each do |alternative|
         winning_counts[alternative] = 0
@@ -320,16 +330,19 @@ module Split
       winning_alternatives.each do |alternative|
         winning_counts[alternative] += 1
       end
-      winning_counts
+      return winning_counts
     end
 
     def find_simulated_winner(simulated_cr_hash)
       # figure out which alternative had the highest simulated conversion rate
-      winning_pair = ['', 0.0]
+      winning_pair = ["",0.0]
       simulated_cr_hash.each do |alternative, rate|
-        winning_pair = [alternative, rate] if rate > winning_pair[1]
+        if rate > winning_pair[1]
+          winning_pair = [alternative, rate]
+        end
       end
-      winning_pair[0]
+      winner = winning_pair[0]
+      return winner
     end
 
     def calc_simulated_conversion_rates(beta_params)
@@ -347,7 +360,7 @@ module Split
         simulated_cr_hash[alternative] = simulated_conversion_rate
       end
 
-      simulated_cr_hash
+      return simulated_cr_hash
     end
 
     def calc_beta_params(goal = nil)
@@ -361,7 +374,7 @@ module Split
 
         beta_params[alternative] = params
       end
-      beta_params
+      return beta_params
     end
 
     def calc_time=(time)
@@ -376,7 +389,7 @@ module Split
       js_id = if goal.nil?
                 name
               else
-                name + '-' + goal
+                name + "-" + goal
               end
       js_id.gsub('/', '--')
     end
@@ -388,7 +401,7 @@ module Split
     end
 
     def load_metadata_from_configuration
-      Split.configuration.experiment_for(@name)[:metadata]
+      metadata = Split.configuration.experiment_for(@name)[:metadata]
     end
 
     def load_metadata_from_redis
@@ -398,7 +411,7 @@ module Split
 
     def load_alternatives_from_configuration
       alts = Split.configuration.experiment_for(@name)[:alternatives]
-      raise ArgumentError, 'Experiment configuration is missing :alternatives array' unless alts
+      raise ArgumentError, "Experiment configuration is missing :alternatives array" unless alts
       if alts.is_a?(Hash)
         alts.keys
       else
@@ -411,9 +424,11 @@ module Split
       when 'set' # convert legacy sets to lists
         alts = redis.smembers(@name)
         redis.del(@name)
-        alts.reverse.each { |alternative| redis.lpush(@name, alternative) }
+        alts.reverse.each {|a| redis.lpush(@name, a) }
+        redis.lrange(@name, 0, -1)
+      else
+        redis.lrange(@name, 0, -1)
       end
-      redis.lrange(@name, 0, -1)
     end
 
     private
@@ -436,7 +451,7 @@ module Split
     def remove_experiment_configuration
       @alternatives.each(&:delete)
       goals_collection.delete
-      redis.del(metadata_key)
+      delete_metadata
       redis.del(@name)
     end
 

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -431,10 +431,6 @@ module Split
       end
     end
 
-    def save_metadata
-      redis.set(metadata_key, @metadata.to_json) unless @metadata.nil?
-    end
-
     private
 
     def redis
@@ -446,12 +442,10 @@ module Split
     end
 
     def persist_experiment_configuration
-      remove_experiment_configuration unless new_record?
-      redis.sadd(:experiments, name) unless redis.sismember(:experiments, name)
-      alternative_names = @alternatives.map(&:name)
-      redis_interface.persist_list(name, alternative_names)
+      redis_interface.add_to_set(:experiments, name)
+      redis_interface.persist_list(name, @alternatives.map(&:name))
       goals_collection.save
-      save_metadata
+      redis.set(metadata_key, @metadata.to_json) unless @metadata.nil?
     end
 
     def remove_experiment_configuration

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -82,7 +82,7 @@ module Split
       if new_record?
         Split.redis.sadd(:experiments, name)
         start unless Split.configuration.start_manually
-        persist
+        persist_configuration
       else
         existing_alternatives = load_alternatives_from_redis
         existing_goals = Split::GoalsCollection.new(@name).load_from_redis
@@ -93,7 +93,7 @@ module Split
           goals_collection.delete
           delete_metadata
           Split.redis.del(@name)
-          persist
+          persist_configuration
         end
       end
 
@@ -450,7 +450,7 @@ module Split
 
     private
 
-    def persist
+    def persist_configuration
       @alternatives.reverse.each { |a| Split.redis.lpush(name, a.name) }
       goals_collection.save
       save_metadata

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -79,8 +79,9 @@ module Split
     def save
       validate!
 
+      redis = Split.redis
       if new_record?
-        Split.redis.sadd(:experiments, name)
+        redis.sadd(:experiments, name)
         start unless Split.configuration.start_manually
         persist_configuration
       elsif configuration_has_changed?
@@ -88,8 +89,8 @@ module Split
         persist_configuration
       end
 
-      Split.redis.hset(experiment_config_key, :resettable, resettable)
-      Split.redis.hset(experiment_config_key, :algorithm, algorithm.to_s)
+      redis.hset(experiment_config_key, :resettable, resettable)
+      redis.hset(experiment_config_key, :algorithm, algorithm.to_s)
       self
     end
 

--- a/lib/split/goals_collection.rb
+++ b/lib/split/goals_collection.rb
@@ -22,7 +22,7 @@ module Split
 
     def save
       return false if @goals.nil?
-      @goals.reverse.each { |goal| Split.redis.lpush(goals_key, goal) }
+      RedisInterface.new.persist_list(goals_key, @goals)
     end
 
     def validate!

--- a/lib/split/redis_interface.rb
+++ b/lib/split/redis_interface.rb
@@ -40,6 +40,10 @@ module Split
       end
     end
 
+    def add_to_set(set_name, value)
+      redis.sadd(set_name, value) unless redis.sismember(set_name, value)
+    end
+
     private
 
     attr_accessor :redis

--- a/lib/split/redis_interface.rb
+++ b/lib/split/redis_interface.rb
@@ -1,0 +1,46 @@
+module Split
+  # Simplifies the interface to Redis.
+  class RedisInterface
+    def initialize
+      self.redis = Split.redis
+    end
+
+    def persist_list(list_name, list_values)
+      max_index = list_length(list_name) - 1
+      list_values.each_with_index do |value, index|
+        if index > max_index
+          add_to_list(list_name, value)
+        else
+          set_list_index(list_name, index, value)
+        end
+      end
+      make_list_length(list_name, list_values.length)
+    end
+
+    def add_to_list(list_name, value)
+      redis.rpush(list_name, value)
+    end
+
+    def set_list_index(list_name, index, value)
+      redis.lset(list_name, index, value)
+    end
+
+    def list_length(list_name)
+      redis.llen(list_name)
+    end
+
+    def remove_last_item_from_list(list_name)
+      redis.rpop(list_name)
+    end
+
+    def make_list_length(list_name, new_length)
+      while list_length(list_name) > new_length
+        remove_last_item_from_list(list_name)
+      end
+    end
+
+    private
+
+    attr_accessor :redis
+  end
+end

--- a/lib/split/redis_interface.rb
+++ b/lib/split/redis_interface.rb
@@ -15,6 +15,7 @@ module Split
         end
       end
       make_list_length(list_name, list_values.length)
+      list_values
     end
 
     def add_to_list(list_name, value)

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -363,11 +363,12 @@ describe Split::Experiment do
       let(:reset_manually) { false }
 
       before do
-        allow(experiment).to receive(:new_record?).and_return(false)
+        experiment.save
         allow(Split.configuration).to receive(:reset_manually).and_return(reset_manually)
         green.increment_participation
         green.increment_participation
-        experiment.set_alternatives_and_options(alternatives: %w(blue red green zip))
+        experiment.set_alternatives_and_options(alternatives: %w(blue red green zip),
+                                                goals: %w(purchase))
         experiment.save
       end
 

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -235,7 +235,7 @@ describe Split::Experiment do
     context 'without winner' do
       it 'returns false' do
         expect(experiment).to_not have_winner
-    end
+      end
     end
   end
 
@@ -259,46 +259,6 @@ describe Split::Experiment do
 
       expect(green.participant_count).to eq(0)
       expect(green.completed_count).to eq(0)
-    end
-
-    context 'when experiment configuration is changed' do
-      before do
-        experiment.set_alternatives_and_options(alternatives: %w(blue red green zip))
-      end
-
-      it 'should reset all alternatives' do
-        experiment.save
-        expect(green.participant_count).to eq(0)
-        expect(green.completed_count).to eq(0)
-      end
-    end
-
-    context 'when reset_manually is set' do
-      let(:reset_manually) { true }
-
-      it 'does not reset any alternatives' do
-        experiment.winner = 'green'
-
-        expect(experiment.next_alternative.name).to eq('green')
-        green.increment_participation
-
-        experiment.reset
-
-        expect(green.participant_count).not_to eq(2)
-        expect(green.completed_count).to eq(0)
-      end
-
-      context 'when experiment configuration is changed' do
-        before do
-          experiment.set_alternatives_and_options(alternatives: %w(blue red green zip))
-        end
-
-        it 'should reset all alternatives' do
-          experiment.save
-          expect(green.participant_count).to eq(2)
-          expect(green.completed_count).to eq(0)
-        end
-      end
     end
 
     it 'should reset the winner' do
@@ -398,6 +358,33 @@ describe Split::Experiment do
       same_experiment_again = same_but_different_alternative
       expect(same_experiment_again.version).to eq(1)
     end
+
+    context 'when experiment configuration is changed' do
+      let(:reset_manually) { false }
+
+      before do
+        allow(experiment).to receive(:new_record?).and_return(false)
+        allow(Split.configuration).to receive(:reset_manually).and_return(reset_manually)
+        green.increment_participation
+        green.increment_participation
+        experiment.set_alternatives_and_options(alternatives: %w(blue red green zip))
+        experiment.save
+      end
+
+      it 'resets all alternatives' do
+        expect(green.participant_count).to eq(0)
+        expect(green.completed_count).to eq(0)
+      end
+
+      context 'when reset_manually is set' do
+        let(:reset_manually) { true }
+
+        it 'does not reset alternatives' do
+          expect(green.participant_count).to eq(2)
+          expect(green.completed_count).to eq(0)
+        end
+      end
+    end
   end
 
   describe 'alternatives passed as non-strings' do
@@ -494,5 +481,4 @@ describe Split::Experiment do
       expect(experiment.calc_winning_alternatives).to be nil
     end
   end
-
 end

--- a/spec/redis_interface_spec.rb
+++ b/spec/redis_interface_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Split::RedisInterface do
   let(:list_name) { 'list_name' }
+  let(:set_name) { 'set_name' }
   let(:interface) { described_class.new }
 
   describe '#persist_list' do
@@ -94,6 +95,17 @@ describe Split::RedisInterface do
       make_list_length
       expect(Split.redis.lindex(list_name, 0)).to eq 'y'
       expect(Split.redis.llen(list_name)).to eq 1
+    end
+  end
+
+  describe '#add_to_set' do
+    subject(:add_to_set) do
+      interface.add_to_set(set_name, 'something')
+    end
+
+    specify do
+      add_to_set
+      expect(Split.redis.sismember(set_name, 'something')).to be true
     end
   end
 end

--- a/spec/redis_interface_spec.rb
+++ b/spec/redis_interface_spec.rb
@@ -6,11 +6,11 @@ describe Split::RedisInterface do
 
   describe '#persist_list' do
     subject(:persist_list) do
-      interface.persist_list(list_name, ['a', 'b', 'c', 'd'])
+      interface.persist_list(list_name, %w(a b c d))
     end
 
     specify do
-      persist_list
+      expect(persist_list).to eq %w(a b c d)
       expect(Split.redis.lindex(list_name, 0)).to eq 'a'
       expect(Split.redis.lindex(list_name, 1)).to eq 'b'
       expect(Split.redis.lindex(list_name, 2)).to eq 'c'
@@ -20,7 +20,7 @@ describe Split::RedisInterface do
 
     context 'list is overwritten but not deleted' do
       specify do
-        persist_list
+        expect(persist_list).to eq %w(a b c d)
         interface.persist_list(list_name, ['z'])
         expect(Split.redis.lindex(list_name, 0)).to eq 'z'
         expect(Split.redis.llen(list_name)).to eq 1

--- a/spec/redis_interface_spec.rb
+++ b/spec/redis_interface_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+describe Split::RedisInterface do
+  let(:list_name) { 'list_name' }
+  let(:interface) { described_class.new }
+
+  describe '#persist_list' do
+    subject(:persist_list) do
+      interface.persist_list(list_name, ['a', 'b', 'c', 'd'])
+    end
+
+    specify do
+      persist_list
+      expect(Split.redis.lindex(list_name, 0)).to eq 'a'
+      expect(Split.redis.lindex(list_name, 1)).to eq 'b'
+      expect(Split.redis.lindex(list_name, 2)).to eq 'c'
+      expect(Split.redis.lindex(list_name, 3)).to eq 'd'
+      expect(Split.redis.llen(list_name)).to eq 4
+    end
+
+    context 'list is overwritten but not deleted' do
+      specify do
+        persist_list
+        interface.persist_list(list_name, ['z'])
+        expect(Split.redis.lindex(list_name, 0)).to eq 'z'
+        expect(Split.redis.llen(list_name)).to eq 1
+      end
+    end
+  end
+
+  describe '#add_to_list' do
+    subject(:add_to_list) do
+      interface.add_to_list(list_name, 'y')
+      interface.add_to_list(list_name, 'z')
+    end
+
+    specify do
+      add_to_list
+      expect(Split.redis.lindex(list_name, 0)).to eq 'y'
+      expect(Split.redis.lindex(list_name, 1)).to eq 'z'
+      expect(Split.redis.llen(list_name)).to eq 2
+    end
+  end
+
+  describe '#set_list_index' do
+    subject(:set_list_index) do
+      interface.add_to_list(list_name, 'y')
+      interface.add_to_list(list_name, 'z')
+      interface.set_list_index(list_name, 0, 'a')
+    end
+
+    specify do
+      set_list_index
+      expect(Split.redis.lindex(list_name, 0)).to eq 'a'
+      expect(Split.redis.lindex(list_name, 1)).to eq 'z'
+      expect(Split.redis.llen(list_name)).to eq 2
+    end
+  end
+
+  describe '#list_length' do
+    subject(:list_length) do
+      interface.add_to_list(list_name, 'y')
+      interface.add_to_list(list_name, 'z')
+      interface.list_length(list_name)
+    end
+
+    specify do
+      expect(list_length).to eq 2
+    end
+  end
+
+  describe '#remove_last_item_from_list' do
+    subject(:remove_last_item_from_list) do
+      interface.add_to_list(list_name, 'y')
+      interface.add_to_list(list_name, 'z')
+      interface.remove_last_item_from_list(list_name)
+    end
+
+    specify do
+      remove_last_item_from_list
+      expect(Split.redis.lindex(list_name, 0)).to eq 'y'
+      expect(Split.redis.llen(list_name)).to eq 1
+    end
+  end
+
+  describe '#make_list_length' do
+    subject(:make_list_length) do
+      interface.add_to_list(list_name, 'y')
+      interface.add_to_list(list_name, 'z')
+      interface.make_list_length(list_name, 1)
+    end
+
+    specify do
+      make_list_length
+      expect(Split.redis.lindex(list_name, 0)).to eq 'y'
+      expect(Split.redis.llen(list_name)).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
We would prefer never to reset the data even if the variants change names, the metadata changes, etc. I've added a `reset_manually` configuration flag that makes this possible, and refactored the Redis persistence so that it applies incremental changes rather than blowing away all experiment data before it's rewritten.