### PR TITLE
Add ability to force alternative on dashboard

### DIFF
--- a/lib/split/dashboard.rb
+++ b/lib/split/dashboard.rb
@@ -30,6 +30,11 @@ module Split
       erb :index
     end
 
+    post '/force_alternative' do
+      Split::User.new(self)[params[:experiment]] = params[:alternative]
+      redirect url('/')
+    end
+
     post '/experiment' do
       @experiment = Split::ExperimentCatalog.find(params[:experiment])
       @alternative = Split::Alternative.new(params[:alternative], params[:experiment])

--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -51,6 +51,10 @@
           <% if alternative.control? %>
             <em>control</em>
           <% end %>
+          <form action="<%= url('force_alternative') + '?experiment=' + experiment.name %>" method='post'>
+            <input type='hidden' name='alternative' value='<%= h alternative.name %>'>
+            <input type="submit" value="Force for current user" class="green">
+          </form>
         </td>
         <td><%= alternative.participant_count %></td>
         <td><%= alternative.unfinished_count %></td>

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -73,6 +73,21 @@ describe Split::Dashboard do
     end
   end
 
+  describe "force alternative" do
+    let!(:user) do
+      Split::User.new(@app, { experiment.name => 'a' })
+    end
+
+    before do
+      allow(Split::User).to receive(:new).and_return(user)
+    end
+
+    it "should set current user's alternative" do
+      post "/force_alternative?experiment=#{experiment.name}", alternative: "b"
+      expect(user[experiment.name]).to eq("b")
+    end
+  end
+
   describe "index page" do
     context "with winner" do
       before { experiment.winner = 'red' }


### PR DESCRIPTION
From #427 -- This simply allows selecting the current users variation/alternative on the dashboard. Helpful for when you're debugging a single alternative and don't want to keep overriding the URL parameter.

Example:

<img width="970" alt="screen shot 2016-09-27 at 9 54 09 pm" src="https://cloud.githubusercontent.com/assets/397982/18898047/f696a28e-84fc-11e6-92aa-a5ea13abfcf1.png">

Note: Not happy with the copy, but it's late and I couldn't think of anything else. :)
