### PR TITLE
Update redis info

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,11 +469,8 @@ Split.configure do |config|
   config.persistence = Split::Persistence::SessionAdapter
   #config.start_manually = false ## new test will have to be started manually from the admin panel. default false
   config.include_rails_helper = true
-  config.redis = "redis://custom.redis.url:6380"
 end
 ```
-
-Split looks for the Redis host in the environment variable `REDIS_URL` then defaults to `redis://localhost:6379` if not specified by configure block.
 
 ### Filtering
 


### PR DESCRIPTION
Setting via config.redis seem to be outdated and does not work. And there are more info on Redis setup down in the docs