### PR TITLE
Remove Explicit Return

### DIFF
--- a/lib/split/alternative.rb
+++ b/lib/split/alternative.rb
@@ -33,7 +33,7 @@ module Split
 
     def p_winner(goal = nil)
       field = set_prob_field(goal)
-      Split.redis.hget(key, field).to_f
+      @p_winner = Split.redis.hget(key, field).to_f
     end
 
     def set_p_winner(prob, goal = nil)

--- a/lib/split/alternative.rb
+++ b/lib/split/alternative.rb
@@ -33,8 +33,7 @@ module Split
 
     def p_winner(goal = nil)
       field = set_prob_field(goal)
-      @p_winner = Split.redis.hget(key, field).to_f
-      return @p_winner
+      Split.redis.hget(key, field).to_f
     end
 
     def set_p_winner(prob, goal = nil)


### PR DESCRIPTION
Hey everybody, first PR for this repo, so let me know if I have overlooked something. I noticed when reading through the alternative.rb file, there is an explicit 'return' of the winner. Is there a reason you choose to do this? This code will always return the last evaluated line. Also, this is set to be an instance variable, but is not used anywhere. Thoughts?

The style guide(https://github.com/bbatsov/ruby-style-guide#no-explicit-return) says:

![screen shot 2016-10-03 at 10 06 58 am](https://cloud.githubusercontent.com/assets/7825131/19040204/27565560-8951-11e6-83bc-f009a9cdf154.png)

