### PR TITLE
Removed a couple old ruby 1.8 hacks

### DIFF
--- a/lib/split/extensions.rb
+++ b/lib/split/extensions.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
-%w[array string].each do |f|
+%w[string].each do |f|
   require "split/extensions/#{f}"
 end

--- a/lib/split/extensions/array.rb
+++ b/lib/split/extensions/array.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-class Array
-  # maintain backwards compatibility with 1.8.7
-  alias_method :sample, :choice unless method_defined?(:sample)
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ Coveralls.wear!
 require 'split'
 require 'ostruct'
 require 'yaml'
-require 'complex' if RUBY_VERSION.match(/1\.8/)
 
 Dir['./spec/support/*.rb'].each { |f| require f }
 


### PR DESCRIPTION
1.8 hasn't been supported by Split in a long time, these couple of hacks must have slipped through the net