### PR TITLE
Avoid variable_size_secure_compare private method

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,9 +439,9 @@ You may want to password protect that page, you can do so with `Rack::Auth::Basi
 Split::Dashboard.use Rack::Auth::Basic do |username, password|
   # Protect against timing attacks:
   # - Use & (do not use &&) so that it doesn't short circuit.
-  # - Use `variable_size_secure_compare` to stop length information leaking
-  ActiveSupport::SecurityUtils.variable_size_secure_compare(username, ENV["SPLIT_USERNAME"]) &
-    ActiveSupport::SecurityUtils.variable_size_secure_compare(password, ENV["SPLIT_PASSWORD"])
+  # - Use digests to stop length information leaking
+  ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SPLIT_USERNAME"])) &
+    ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SPLIT_PASSWORD"]))
 end
 
 # Apps without activesupport


### PR DESCRIPTION
Use public secure_compare with digests to do the same work as private method variable_size_secure_compare.