### PR TITLE
Blocked a few more common bot user agents

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -48,7 +48,9 @@ module Split
         'spider' => 'generic web spider',
         'UnwindFetchor' => 'Gnip crawler',
         'WordPress' => 'WordPress spider',
+        'YandexAccessibilityBot' => 'Yandex accessibility spider',
         'YandexBot' => 'Yandex spider',
+        'YandexMobileBot' => 'Yandex mobile spider',
         'ZIBB' => 'ZIBB spider',
 
         # HTTP libraries
@@ -73,10 +75,13 @@ module Split
         'facebookexternalhit' => 'facebook bot',
         'Feedfetcher-Google' => 'Google Feedfetcher',
         'https://developers.google.com/+/web/snippet' => 'Google+ Snippet Fetcher',
+        'LinkedInBot' => 'LinkedIn bot',
         'LongURL' => 'URL expander service',
         'NING' => 'NING - Yet Another Twitter Swarmer',
+        'Pinterest' => 'Pinterest Bot',
         'redditbot' => 'Reddit Bot',
         'ShortLinkTranslate' => 'Link shortener',
+        'Slackbot' => 'Slackbot link expander',
         'TweetmemeBot' => 'TweetMeMe Crawler',
         'Twitterbot' => 'Twitter URL expander',
         'UnwindFetch' => 'Gnip URL expander',


### PR DESCRIPTION
I've discovered a few more common bots that are probably worth adding to the default block list:
* YandexAccessibilityBot http://yandex.com/bots
* YandexMobileBot http://yandex.com/bots
* LinkedInBot http://www.linkedin.com
* Pinterest http://www.pinterest.com/bot.html
* Slackbot https://api.slack.com/robots
