### PR TITLE
Enumeration of a User's Experiments that Respects the db_failover Option

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -96,6 +96,14 @@ module Split
       Split.configuration.db_failover_on_db_error.call(e)
     end
 
+    def ab_active_experiments()
+      ab_user.active_experiments
+    rescue => e
+      raise unless Split.configuration.db_failover
+      Split.configuration.db_failover_on_db_error.call(e)
+    end
+
+
     def override_present?(experiment_name)
       override_alternative(experiment_name)
     end


### PR DESCRIPTION
Use case: At the start of each of our Rail app's request, we grab the current user's set of experiments to be included in application logs. We had been using `ab_user.active_experiments` to grab this information, but we discovered that this function did not honor the `db_failover` option (ie - it resulted in our application crashing due to the unhandled exception). This PR adds a new convenience function which returns a user's set of experiments while also honoring the `db_failover` configuration setting.