### PR TITLE
Allow configuration of how often winning alternatives are recalculated

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -716,7 +716,7 @@ Style/LineEndConcatenation:
                  line end.
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
   Enabled: false
@@ -816,7 +816,7 @@ Style/OneLineConditional:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: false
 
-Style/OpMethod:
+Naming/BinaryOperatorParameter:
   Description: 'When defining binary operators, name the argument other.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ As per this [blog post](http://www.evanmiller.org/how-not-to-run-an-ab-test.html
 
 The second option uses simulations from a beta distribution to determine the probability that the given alternative is the winner compared to all other alternatives. You can view these probabilities by clicking on the drop-down menu labeled "Confidence." This option should be used when the experiment has more than just 1 control and 1 alternative. It can also be used for a simple, 2-alternative A/B test.
 
+Calculating the beta-distribution simulations for a large number of experiments can be slow, so the results are cached. You can specify how often they should be recalculated (the default is once per day).
+
+```ruby
+Split.configure do |config|
+  config.winning_alternative_recalculation_interval = 3600 # 1 hour
+end
+```
+
 ## Extras
 
 ### Weighted alternatives

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -25,6 +25,7 @@ module Split
     attr_accessor :on_before_experiment_delete
     attr_accessor :include_rails_helper
     attr_accessor :beta_probability_simulations
+    attr_accessor :winning_alternative_recalculation_interval
     attr_accessor :redis
 
     attr_reader :experiments
@@ -217,6 +218,7 @@ module Split
       @algorithm = Split::Algorithms::WeightedSample
       @include_rails_helper = true
       @beta_probability_simulations = 10000
+      @winning_alternative_recalculation_interval = 60 * 60 * 24 # 1 day
       @redis = ENV.fetch(ENV.fetch('REDIS_PROVIDER', 'REDIS_URL'), 'redis://localhost:6379')
     end
 

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -262,10 +262,11 @@ module Split
     end
 
     def calc_winning_alternatives
-      # Super simple cache so that we only recalculate winning alternatives once per day
-      days_since_epoch = Time.now.utc.to_i / 86400
+      # Cache the winning alternatives so we recalculate them once per the specified interval.
+      intervals_since_epoch =
+        Time.now.utc.to_i / Split.configuration.winning_alternative_recalculation_interval
 
-      if self.calc_time != days_since_epoch
+      if self.calc_time != intervals_since_epoch
         if goals.empty?
           self.estimate_winning_alternative
         else
@@ -274,7 +275,7 @@ module Split
           end
         end
 
-        self.calc_time = days_since_epoch
+        self.calc_time = intervals_since_epoch
 
         self.save
       end


### PR DESCRIPTION
If you're running A/B tests for a short period of time, the "Probability of being Winner" numbers can be unhelpful or misleading.