### PR TITLE
Avoid z_score numeric exception for conversion rates >1

### DIFF
--- a/lib/split/alternative.rb
+++ b/lib/split/alternative.rb
@@ -119,6 +119,9 @@ module Split
       n_a = alternative.participant_count
       n_c = control.participant_count
 
+      # can't calculate zscore for P(x) > 1
+      return 'N/A' if p_a > 1 || p_c > 1
+
       z_score = Split::Zscore.calculate(p_a, n_a, p_c, n_c)
     end
 

--- a/spec/alternative_spec.rb
+++ b/spec/alternative_spec.rb
@@ -273,6 +273,18 @@ describe Split::Alternative do
       expect(control.z_score(goal1)).to eq('N/A')
       expect(control.z_score(goal2)).to eq('N/A')
     end
+
+    it "should not blow up for Conversion Rates > 1" do
+      control = experiment.control
+      control.participant_count = 3474
+      control.set_completed_count(4244)
+
+      alternative2.participant_count = 3434
+      alternative2.set_completed_count(4358)
+
+      expect { control.z_score }.not_to raise_error
+      expect { alternative2.z_score }.not_to raise_error
+    end
   end
 
   describe "extra_info" do


### PR DESCRIPTION
At normal operation, it's not possible for an experiment alternative
 to have a `participant_count` > `completed_count`.
However, by manually using `increment_participation`
 (for a custom use-case or by accident) you can arrive
 on such a situation.

If that happens, `Zscore.calculate` produces an error that
 propagates all the way up to the web view.

Solution:
In the cornercase of a conversion rates taking a value >1,
 it makes no sense to calculate a zscore value at all.
An escape clause was added