### PR TITLE
Add failing spec for multiple Set-Cookie headers bug

### DIFF
--- a/spec/persistence/cookie_adapter_spec.rb
+++ b/spec/persistence/cookie_adapter_spec.rb
@@ -40,4 +40,9 @@ describe Split::Persistence::CookieAdapter do
     expect(subject["my_key"]).to eq("my_value")
   end
 
+  it "puts multiple experiments in a single cookie" do
+    subject["foo"] = "FOO"
+    subject["bar"] = "BAR"
+    expect(context.response.headers["Set-Cookie"]).to match(/\Asplit=%7B%22foo%22%3A%22FOO%22%2C%22bar%22%3A%22BAR%22%7D; path=\/; expires=[a-zA-Z]{3}, \d{2} [a-zA-Z]{3} \d{4} \d{2}:\d{2}:\d{2} -0000\Z/)
+  end
 end


### PR DESCRIPTION
This demonstrates the problem I mentioned here: https://github.com/splitrb/split/pull/490/files#r161960030

> [Version 3.1.0] may be causing split to send back multiple Set-Cookie headers in the case where a participant is involved in more than one split test. Version 3.0.0 did not have this problem. But after upgrading to 3.1.0 (which included this PR), I started seeing one Set-Cookie response headers for every experiment mentioned in the cookie submitted by the client.

> In a few cases, the cookies had enough experiments in them that my load balancer rejected the response as invalid.

> Downgrading to 3.0.0 fixed the problem.

> I think that @response.set_cookie is writing a new cookie each time it is called. However, @cookies[:split] was overwriting the previous value of the cookie in place.