### PR TITLE
Improve performance of RedisInterface#make_list_length by using LTRIM command

### DIFF
--- a/lib/split/redis_interface.rb
+++ b/lib/split/redis_interface.rb
@@ -35,9 +35,7 @@ module Split
     end
 
     def make_list_length(list_name, new_length)
-      while list_length(list_name) > new_length
-        remove_last_item_from_list(list_name)
-      end
+      redis.ltrim(list_name, 0, new_length - 1)
     end
 
     def add_to_set(set_name, value)


### PR DESCRIPTION
See Redis `LTRIM` command docs [here](https://redis.io/commands/ltrim).

Commit description:

> This implementation will only execute 1 to Redis command, instead of
> 2n (n being the total number of elements to trim from the list).
> 
> The operation will still take O(n) time, but the constants will be
> much better, since only 1 network round trip is required.

A small improvement, but I happened to notice while looking around the code. Admittedly, it doesn't seem this method is currently used with a lot of data, but I think it's easy to imagine it having a significant impact on performance if used differently in the future.

I'd be happy to submit a benchmark if that would be helpful :).