### PR TITLE
Upgrade fakeredis to 0.7.0

### DIFF
--- a/spec/split_spec.rb
+++ b/spec/split_spec.rb
@@ -15,19 +15,19 @@ RSpec.describe Split do
       Split.redis = 'redis://localhost:6379'
       expect(Split.redis).to be_a(Redis)
 
-      client = Split.redis.client
-      expect(client.host).to eq("localhost")
-      expect(client.port).to eq(6379)
+      client = Split.redis.connection
+      expect(client[:host]).to eq("localhost")
+      expect(client[:port]).to eq(6379)
     end
 
     it 'accepts an options hash' do
       Split.redis = {host: 'localhost', port: 6379, db: 12}
       expect(Split.redis).to be_a(Redis)
 
-      client = Split.redis.client
-      expect(client.host).to eq("localhost")
-      expect(client.port).to eq(6379)
-      expect(client.db).to eq(12)
+      client = Split.redis.connection
+      expect(client[:host]).to eq("localhost")
+      expect(client[:port]).to eq(6379)
+      expect(client[:db]).to eq(12)
     end
 
     it 'accepts a valid Redis instance' do

--- a/split.gemspec
+++ b/split.gemspec
@@ -40,5 +40,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',        '~> 12'
   s.add_development_dependency 'rspec',       '~> 3.7'
   s.add_development_dependency 'pry',         '~> 0.10'
-  s.add_development_dependency 'fakeredis',   '~> 0.6'
+  s.add_development_dependency 'fakeredis',   '~> 0.7'
 end


### PR DESCRIPTION
Fixes #511 

The implementation of #client changed on the redis-rb library on ~> 4.0.1. Which was moved the `#_client`. But as these specs were only checking host/port configs seemed better to call `#connection` instead.

`#connection` returns a Hash from the client settings.

