### PR TITLE
Fix cookie header duplication

### DIFF
--- a/spec/persistence/cookie_adapter_spec.rb
+++ b/spec/persistence/cookie_adapter_spec.rb
@@ -40,4 +40,9 @@ describe Split::Persistence::CookieAdapter do
     expect(subject["my_key"]).to eq("my_value")
   end
 
+  it "puts multiple experiments in a single cookie" do
+    subject["foo"] = "FOO"
+    subject["bar"] = "BAR"
+    expect(context.response.headers["Set-Cookie"]).to match(/\Asplit=%7B%22foo%22%3A%22FOO%22%2C%22bar%22%3A%22BAR%22%7D; path=\/; expires=[a-zA-Z]{3}, \d{2} [a-zA-Z]{3} \d{4} \d{2}:\d{2}:\d{2} -0000\Z/)
+  end
 end

--- a/spec/persistence/cookie_adapter_spec.rb
+++ b/spec/persistence/cookie_adapter_spec.rb
@@ -7,7 +7,7 @@ describe Split::Persistence::CookieAdapter do
   let(:env) { Rack::MockRequest.env_for("http://example.com:8080/") }
   let(:request) { Rack::Request.new(env) }
   let(:response) { Rack::MockResponse.new(200, {}, "") }
-  let(:context) { double(request: request, response: response) }
+  let(:context) { double(request: request, response: response, cookies: CookiesMock.new) }
   subject { Split::Persistence::CookieAdapter.new(context) }
 
   describe "#[] and #[]=" do
@@ -45,4 +45,18 @@ describe Split::Persistence::CookieAdapter do
     subject["bar"] = "BAR"
     expect(context.response.headers["Set-Cookie"]).to match(/\Asplit=%7B%22foo%22%3A%22FOO%22%2C%22bar%22%3A%22BAR%22%7D; path=\/; expires=[a-zA-Z]{3}, \d{2} [a-zA-Z]{3} \d{4} \d{2}:\d{2}:\d{2} -0000\Z/)
   end
+
+  it "ensure other added cookies are not overriden" do
+    context.response.set_cookie 'dummy', 'wow'
+    subject["foo"] = "FOO"
+    expect(context.response.headers["Set-Cookie"]).to include("dummy=wow")
+    expect(context.response.headers["Set-Cookie"]).to include("split=")
+  end
+
+  it "uses ActionDispatch::Cookie when available for cookie writing" do
+    allow(subject).to receive(:action_dispatch?).and_return(true)
+    subject["foo"] = "FOO"
+    expect(subject['foo']).to eq('FOO')
+  end
+
 end


### PR DESCRIPTION
References #508 and fix a bug introduced by #490

Using ActionDispatch::Cookies from rails, manages flushing/replacing cookies on its own. Sinatra also have something like it on Sinatra::Cookies.

When using Rack directly you have to take care of that. Each time set_cookie was called it was adding another Set-Cookie entry to response.

This PR does:
- Adds back compatibility to ActionDispatch::Cookies. Tries to use it when available
- Fallbacks to parsing/replacing the Set-Cookie header on any Rack app - I still want to think of a more generic/best way to do this. 
