### PR TITLE
test rails 5.2 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ gemfile:
   - gemfiles/4.2.gemfile
   - gemfiles/5.0.gemfile
   - gemfiles/5.1.gemfile
+  - gemfiles/5.2.gemfile
+
 
 matrix:
   exclude:
@@ -30,6 +32,15 @@ matrix:
     gemfile: gemfiles/5.0.gemfile
   - rvm: 2.2.0
     gemfile: gemfiles/5.1.gemfile
+  - rvm: 1.9.3
+    gemfile: gemfiles/5.2.gemfile
+  - rvm: 2.0
+    gemfile: gemfiles/5.2.gemfile
+  - rvm: 2.1
+    gemfile: gemfiles/5.2.gemfile
+  - rvm: 2.2.0
+    gemfile: gemfiles/5.2.gemfile
+
 
 before_install:
   - gem update --system && gem install bundler

--- a/Appraisals
+++ b/Appraisals
@@ -4,10 +4,12 @@ end
 
 appraise "5.0" do
   gem "rails", "~> 5.0"
-  gem "sinatra", git: "https://github.com/sinatra/sinatra"
 end
 
 appraise "5.1" do
   gem "rails", "~> 5.1"
-  gem "sinatra", git: "https://github.com/sinatra/sinatra"
+end
+
+appraise "5.2" do
+  gem "rails", "~> 5.2"
 end

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -5,6 +5,5 @@ source "https://rubygems.org"
 gem "appraisal"
 gem "codeclimate-test-reporter"
 gem "rails", "~> 5.1"
-gem "sinatra", git: "https://github.com/sinatra/sinatra"
 
 gemspec path: "../"

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "codeclimate-test-reporter"
-gem "rails", "~> 5.0"
+gem "rails", "~> 5.2"
 
 gemspec path: "../"


### PR DESCRIPTION
This adds rails 5.2 to appraisals for testing.  I also removed the dependency on git version of sinatra for newer rubies as that does not seem to be necessary at this point.