### PR TITLE
update ruby versions for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ rvm:
   - 2.1
   - 2.2.0
   - 2.2.2
-  - 2.4.2
+  - 2.4.3
+  - 2.5.1
 
 gemfile:
   - gemfiles/4.2.gemfile


### PR DESCRIPTION
This adds 2.5.1 to the travis config and updates to the latest 2.4