### PR TITLE
Add Facebot crawler to list of bots

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -74,6 +74,7 @@ module Split
         'bitlybot' => 'bit.ly bot',
         'bot@linkfluence.net' => 'Linkfluence bot',
         'facebookexternalhit' => 'facebook bot',
+        'Facebot' => 'Facebook crawler',
         'Feedfetcher-Google' => 'Google Feedfetcher',
         'https://developers.google.com/+/web/snippet' => 'Google+ Snippet Fetcher',
         'LinkedInBot' => 'LinkedIn bot',


### PR DESCRIPTION
This PR adds "Facebot" to list of bots.

See: https://developers.facebook.com/docs/sharing/webmasters/crawler/#facebot-crawler