### PR TITLE
Ignore previewing requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Split.configure do |config|
   # IP config
   config.ignore_ip_addresses << '81.19.48.130' # or regex: /81\.19\.48\.[0-9]+/
 
-  # or provide your own filter functionality, the default is proc{ |request| is_robot? || is_ignored_ip_address? }
+  # or provide your own filter functionality, the default is proc{ |request| is_robot? || is_ignored_ip_address? || is_preview? }
   config.ignore_filter = -> (request) { CustomExcludeLogic.excludes?(request) }
 end
 ```

--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -122,11 +122,15 @@ module Split
     end
 
     def exclude_visitor?
-      instance_eval(&Split.configuration.ignore_filter) || is_ignored_ip_address? || is_robot?
+      instance_eval(&Split.configuration.ignore_filter) || is_ignored_ip_address? || is_robot? || is_preview?
     end
 
     def is_robot?
       defined?(request) && request.user_agent =~ Split.configuration.robot_regex
+    end
+
+    def is_preview?
+      defined?(request) && defined?(request.headers) && request.headers['x-purpose'] == 'preview'
     end
 
     def is_ignored_ip_address?

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -699,6 +699,14 @@ describe Split::Helper do
     end
   end
 
+  describe 'when user is previewing' do
+    before(:each) do
+      @request = OpenStruct.new(headers: { 'x-purpose' => 'preview' })
+    end
+
+    it_behaves_like "a disabled test"
+  end
+
   describe 'versioned experiments' do
     it "should use version zero if no version is present" do
       alternative_name = ab_test('link_color', 'blue', 'red')


### PR DESCRIPTION
Facebook, Google etc. have started to do prefetching of landing pages used in campaigns in their mobile apps - without any user interactions.

This PR adds a method to detect these requests and ignore them, as they're non-interactive by the user.

See: https://support.google.com/dcm/partner/answer/7295804?hl=en and https://www.facebook.com/business/help/www/1514372351922333