### PR TITLE
Fix binding of ignore_filter

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -122,7 +122,7 @@ module Split
     end
 
     def exclude_visitor?
-      instance_eval(&Split.configuration.ignore_filter) || is_ignored_ip_address? || is_robot? || is_preview?
+      instance_exec(request, &Split.configuration.ignore_filter) || is_ignored_ip_address? || is_robot? || is_preview?
     end
 
     def is_robot?


### PR DESCRIPTION
This PR fixes the context in which the `ignore_filter` is called. This is needed when using the helper methods in a context of an eg. Rails helper.

To illustrate the difference:

```ruby
Split.configure do |config|
  config.ignore_filter = ->(request) { puts "{request.class.to_s}" }
end
```

When calling `ab_test` in a controller, the output is:

    <ActionDispatch::Request ...>

But when using `ab_test` in a helper, the output is:

    <Class...>

This is especially funky due to Rails' delegation of eg. `#headers`, meaning that calling `request.headers` in the `ignore_filter` would have two different meanings - in helpers, it would call `headers` on the **response**, while in controllers it would call `headers` on the **request** (as intended)

This PR fixes the issue and should preserve backwards-compatibility (for methods with `request` as argument in the proc).