### PR TITLE
Do not storage alternative in cookie if experiment has a winner

### DIFF
--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -82,7 +82,7 @@ module Split
         end
       end
 
-      @user[@experiment.key] = alternative.name if should_store_alternative?
+      @user[@experiment.key] = alternative.name if !@experiment.has_winner? && should_store_alternative?
       @alternative_choosen = true
       run_callback context, Split.configuration.on_trial unless @options[:disabled] || Split.configuration.disabled?
       alternative

--- a/spec/trial_spec.rb
+++ b/spec/trial_spec.rb
@@ -275,5 +275,17 @@ describe Split::Trial do
         trial.choose!
       end
     end
+
+    context 'when experiment has winner' do
+      let(:trial) do
+        experiment.winner = 'cart'
+        Split::Trial.new(:user => user, :experiment => experiment)
+      end
+
+      it 'does not store' do
+        expect(user).to_not receive("[]=")
+        trial.choose!
+      end
+    end
   end
 end


### PR DESCRIPTION
The `Trial#choose!` method always persist the alternative for an experiment regardless if it has a winner or no. The only difference for them is that they don't `increment_participation` when the experiment has a winner.

The reason why we sometimes see closed experiments and sometimes we don't in the cookies is because when `allow_multiple_experiments` was introduced as a new feature in Split that required to `cleanup_old_experiments` before a new enrolment https://github.com/splitrb/split/commit/a1bc236a0dbb725956120578a339aec26bfb272c. This happens at the beginning of the enrolment, that means that if the last experiment enrolled was closed it will be persisted in the cookie, but if not it will be cleaned for any further enrolment on another experiment.