### PR TITLE
Avoid hitting up on redis for robots/excluded users.

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -8,7 +8,7 @@ module Split
     def ab_test(metric_descriptor, control = nil, *alternatives)
       begin
         experiment = ExperimentCatalog.find_or_initialize(metric_descriptor, control, *alternatives)
-        alternative = if Split.configuration.enabled
+        alternative = if Split.configuration.enabled && !exclude_visitor?
           experiment.save
           raise(Split::InvalidExperimentsFormatError) unless (Split.configuration.experiments || {}).fetch(experiment.name.to_sym, {})[:combined_experiments].nil?
           trial = Trial.new(:user => ab_user, :experiment => experiment,

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -564,6 +564,11 @@ describe Split::Helper do
         expect(alternative).to eq experiment.control.name
       end
 
+      it 'should not create a experiment' do
+        ab_test('link_color', 'blue', 'red')
+        expect(Split::Experiment.new('link_color')).to be_a_new_record
+      end
+
       it "should not increment the participation count" do
 
         previous_red_count = Split::Alternative.new('red', 'link_color').participant_count


### PR DESCRIPTION
Closes #482

When Split is disabled or user is excluded, we avoid hitting redis up to load/save the experiment.

This should save a few calls if the a/b is exposed on a public page, or something.

The helper still follows up the logic of building an Split::Experiment to correctly return the control alternative.

Note that on this moment `ExperimentCatalog.find_or_initialize` does actually hit redis to 'find' an existing experiment.