### PR TITLE
Fixing weight persistence

### DIFF
--- a/lib/split/alternative.rb
+++ b/lib/split/alternative.rb
@@ -6,20 +6,25 @@ module Split
     attr_accessor :weight
     attr_accessor :recorded_info
 
-    def initialize(name, experiment_name)
+    def initialize(data, experiment_name)
       @experiment_name = experiment_name
-      if Hash === name
-        @name = name.keys.first
-        @weight = name.values.first
+      if Hash === data
+        @name = data.keys.first.to_s
+        @weight = data.values.first.to_i
+      elsif String === data and data.include?("=>")
+        data = data.gsub(/{|}|\s|"|'/, "").split("=>")
+        @name = data[0].to_s
+        @weight = data[1].to_i
       else
-        @name = name
+        @name = data.to_s
         @weight = 1
       end
+
       p_winner = 0.0
     end
 
     def to_s
-      name
+      {name => weight}
     end
 
     def goals

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -420,7 +420,7 @@ module Split
     end
 
     def load_alternatives_from_redis
-      case redis.type(@name)
+      alternatives = case redis.type(@name)
       when 'set' # convert legacy sets to lists
         alts = redis.smembers(@name)
         redis.del(@name)
@@ -428,6 +428,9 @@ module Split
         redis.lrange(@name, 0, -1)
       else
         redis.lrange(@name, 0, -1)
+      end
+      alternatives.map do |alt|
+        Split::Alternative.new(alt, name)
       end
     end
 
@@ -443,7 +446,7 @@ module Split
 
     def persist_experiment_configuration
       redis_interface.add_to_set(:experiments, name)
-      redis_interface.persist_list(name, @alternatives.map(&:name))
+      redis_interface.persist_list(name, @alternatives.map { |alt| alt.to_s })
       goals_collection.save
       redis.set(metadata_key, @metadata.to_json) unless @metadata.nil?
     end
@@ -456,10 +459,10 @@ module Split
     end
 
     def experiment_configuration_has_changed?
-      existing_alternatives = load_alternatives_from_redis
+      existing_alternatives = load_alternatives_from_redis.map { |alt| alt.to_s }
       existing_goals = Split::GoalsCollection.new(@name).load_from_redis
       existing_metadata = load_metadata_from_redis
-      existing_alternatives != @alternatives.map(&:name) ||
+      existing_alternatives != @alternatives.map { |alt| alt.to_s } ||
         existing_goals != @goals ||
         existing_metadata != @metadata
     end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -183,8 +183,8 @@ describe Split::Helper do
       ab_test('link_color', {'blue' => 0.01}, 'red' => 0.2)
       experiment = Split::ExperimentCatalog.find('link_color')
       expect(experiment.alternatives.map(&:name)).to eq(['blue', 'red'])
-      # TODO: persist alternative weights
-      # expect(experiment.alternatives.collect{|a| a.weight}).to eq([0.01, 0.2])
+
+      expect(experiment.alternatives.collect{|a| a.weight}).to eq([0.01, 0.2])
     end
 
     it "should only let a user participate in one experiment at a time" do
@@ -248,7 +248,7 @@ describe Split::Helper do
           pending "this requires user store reset on first call not depending on whelther it is current trial"
           @params = { 'ab_test' => { 'test_1' => 'test-alt' } }
 
-          expect(ab_test(:test_0, {'control' => 0}, {"test-alt" => 100})).to eq 'control'
+          expect(ab_test(:test_0, {'control' => 0}, {"test-alt" => 100})).to eq 'test-alt'
           expect(ab_test(:test_1, {'control' => 100}, {"test-alt" => 1})).to eq 'test-alt'
         end
 


### PR DESCRIPTION
When initializing an alternative, allow the existing weight to be passed in, to persist weights when storing / fetching from Redis