### PR TITLE
Fix Bigdecimal warnings

### DIFF
--- a/lib/split/dashboard/helpers.rb
+++ b/lib/split/dashboard/helpers.rb
@@ -19,9 +19,9 @@ module Split
 
     def round(number, precision = 2)
       begin
-        BigDecimal.new(number.to_s)
+        BigDecimal(number.to_s)
       rescue ArgumentError
-        BigDecimal.new(0)
+        BigDecimal(0)
       end.round(precision).to_f
     end
 


### PR DESCRIPTION
* replace BigDecimal.new() with BigDecimal()
* 3.3.1 and HEAD are affected, most likely affects historical versions as well
* this resolves the following deprecation warning when running Ruby >= 2.5.0rc1:

```
/Users/username/src/project/.gems/gems/split-3.3.1/lib/split/dashboard/helpers.rb:24: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```

