### PR TITLE
Fix `force_aleternative` for experiments with incremented version

### DIFF
--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -73,7 +73,7 @@
           <% if alternative.control? %>
             <em>control</em>
           <% end %>
-          <form action="<%= url('force_alternative') + '?experiment=' + experiment.name %>" method='post'>
+          <form action="<%= url('force_alternative') + '?experiment=' + experiment.key %>" method='post'>
             <input type='hidden' name='alternative' value='<%= h alternative.name %>'>
             <input type="submit" value="Force for current user" class="green">
           </form>

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -90,17 +90,16 @@ describe Split::Dashboard do
     end
 
     context "increment version" do
+      let!(:user) do
+        Split::User.new(@app, { "#{experiment.name}:#{experiment.version}" => 'a' })
+      end
+
       before do
         allow(Split::User).to receive(:new).and_return(user)
         experiment.increment_version
       end
 
-      let!(:user) do
-        Split::User.new(@app, { "#{experiment.name}:#{experiment.version}" => 'a' })
-      end
-
       it "should set current user's alternative" do
-        puts experiment.version
         post "/force_alternative?experiment=#{experiment.key}", alternative: "b"
         expect(user[experiment.key]).to eq("b")
       end

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -74,17 +74,36 @@ describe Split::Dashboard do
   end
 
   describe "force alternative" do
-    let!(:user) do
-      Split::User.new(@app, { experiment.name => 'a' })
+    context "initial" do
+      let!(:user) do
+        Split::User.new(@app, { experiment.name => 'a' })
+      end
+
+      before do
+        allow(Split::User).to receive(:new).and_return(user)
+      end
+
+      it "should set current user's alternative" do
+        post "/force_alternative?experiment=#{experiment.key}", alternative: "b"
+        expect(user[experiment.key]).to eq("b")
+      end
     end
 
-    before do
-      allow(Split::User).to receive(:new).and_return(user)
-    end
+    context "increment version" do
+      before do
+        allow(Split::User).to receive(:new).and_return(user)
+        experiment.increment_version
+      end
 
-    it "should set current user's alternative" do
-      post "/force_alternative?experiment=#{experiment.name}", alternative: "b"
-      expect(user[experiment.name]).to eq("b")
+      let!(:user) do
+        Split::User.new(@app, { "#{experiment.name}:#{experiment.version}" => 'a' })
+      end
+
+      it "should set current user's alternative" do
+        puts experiment.version
+        post "/force_alternative?experiment=#{experiment.key}", alternative: "b"
+        expect(user[experiment.key]).to eq("b")
+      end
     end
   end
 


### PR DESCRIPTION
In dashboard, `force_alternative` doesn't work for experiments with incremented version to look for key without version.

This PR fixes this issue and `force_alternative` works for experiments with incremented version.