### PR TITLE
Increment participant count when `force_alternative` pushed

### DIFF
--- a/lib/split/dashboard.rb
+++ b/lib/split/dashboard.rb
@@ -33,6 +33,8 @@ module Split
     end
 
     post '/force_alternative' do
+      alternative = Split::Alternative.new(params[:alternative], params[:experiment])
+      alternative.increment_participation
       Split::User.new(self)[params[:experiment]] = params[:alternative]
       redirect url('/')
     end

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -75,7 +75,7 @@ describe Split::Dashboard do
 
   describe "force alternative" do
     let!(:user) do
-      Split::User.new(@app, { experiment.name => 'a' })
+      Split::User.new(@app, { experiment.name => 'red' })
     end
 
     before do
@@ -83,8 +83,10 @@ describe Split::Dashboard do
     end
 
     it "should set current user's alternative" do
-      post "/force_alternative?experiment=#{experiment.name}", alternative: "b"
-      expect(user[experiment.name]).to eq("b")
+      blue_link.participant_count = 7
+      post "/force_alternative?experiment=#{experiment.name}", alternative: "blue"
+      expect(user[experiment.name]).to eq("blue")
+      expect(blue_link.participant_count).to eq(8)
     end
   end
 


### PR DESCRIPTION
Fix https://github.com/splitrb/split/issues/563 by just incrementing participant count when `force_alternative` pushed.
Please review this PR.