### PR TITLE
Fix `force_aleternative` for experiments with incremented version

### DIFF
--- a/lib/split/dashboard.rb
+++ b/lib/split/dashboard.rb
@@ -33,9 +33,10 @@ module Split
     end
 
     post '/force_alternative' do
-      alternative = Split::Alternative.new(params[:alternative], params[:experiment])
+      experiment = Split::ExperimentCatalog.find(params[:experiment])
+      alternative = Split::Alternative.new(params[:alternative], experiment.name)
       alternative.increment_participation
-      Split::User.new(self)[params[:experiment]] = params[:alternative]
+      Split::User.new(self)[experiment.key] = alternative.name
       redirect url('/')
     end
 

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -74,19 +74,39 @@ describe Split::Dashboard do
   end
 
   describe "force alternative" do
-    let!(:user) do
-      Split::User.new(@app, { experiment.name => 'red' })
+    context "initial version" do
+      let!(:user) do
+        Split::User.new(@app, { experiment.name => 'red' })
+      end
+
+      before do
+        allow(Split::User).to receive(:new).and_return(user)
+      end
+
+      it "should set current user's alternative" do
+        blue_link.participant_count = 7
+        post "/force_alternative?experiment=#{experiment.name}", alternative: "blue"
+        expect(user[experiment.key]).to eq("blue")
+        expect(blue_link.participant_count).to eq(8)
+      end
     end
 
-    before do
-      allow(Split::User).to receive(:new).and_return(user)
-    end
+    context "incremented version" do
+      let!(:user) do
+        experiment.increment_version
+        Split::User.new(@app, { "#{experiment.name}:#{experiment.version}" => 'red' })
+      end
 
-    it "should set current user's alternative" do
-      blue_link.participant_count = 7
-      post "/force_alternative?experiment=#{experiment.name}", alternative: "blue"
-      expect(user[experiment.name]).to eq("blue")
-      expect(blue_link.participant_count).to eq(8)
+      before do
+        allow(Split::User).to receive(:new).and_return(user)
+      end
+
+      it "should set current user's alternative" do
+        blue_link.participant_count = 7
+        post "/force_alternative?experiment=#{experiment.name}", alternative: "blue"
+        expect(user[experiment.key]).to eq("blue")
+        expect(blue_link.participant_count).to eq(8)
+      end
     end
   end
 


### PR DESCRIPTION
I closed https://github.com/splitrb/split/pull/565, and resend this patch.

In dashboard, `force_alternative` doesn't work for experiments with incremented version to look for key without version.
This PR fixes this issue and `force_alternative` works for experiments with incremented version.

Please review this.