### PR TITLE
Persist alternative weights

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -463,8 +463,7 @@ module Split
       redis.del(@name)
     end
 
-    def
-      experiment_configuration_has_changed?
+    def experiment_configuration_has_changed?
       existing_alternatives = load_alternatives_from_redis
       existing_goals = Split::GoalsCollection.new(@name).load_from_redis
       existing_metadata = load_metadata_from_redis

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -420,14 +420,22 @@ module Split
     end
 
     def load_alternatives_from_redis
-      case redis.type(@name)
-      when 'set' # convert legacy sets to lists
-        alts = redis.smembers(@name)
-        redis.del(@name)
-        alts.reverse.each {|a| redis.lpush(@name, a) }
-        redis.lrange(@name, 0, -1)
-      else
-        redis.lrange(@name, 0, -1)
+      alternatives = case redis.type(@name)
+                     when 'set' # convert legacy sets to lists
+                       alts = redis.smembers(@name)
+                       redis.del(@name)
+                       alts.reverse.each {|a| redis.lpush(@name, a) }
+                       redis.lrange(@name, 0, -1)
+                     else
+                       redis.lrange(@name, 0, -1)
+                     end
+      alternatives.map do |alt|
+        alt = begin
+                JSON.parse(alt)
+              rescue
+                alt
+              end
+        Split::Alternative.new(alt, @name)
       end
     end
 
@@ -443,7 +451,7 @@ module Split
 
     def persist_experiment_configuration
       redis_interface.add_to_set(:experiments, name)
-      redis_interface.persist_list(name, @alternatives.map(&:name))
+      redis_interface.persist_list(name, @alternatives.map{|alt| {alt.name => alt.weight}.to_json})
       goals_collection.save
       redis.set(metadata_key, @metadata.to_json) unless @metadata.nil?
     end
@@ -455,11 +463,12 @@ module Split
       redis.del(@name)
     end
 
-    def experiment_configuration_has_changed?
+    def
+      experiment_configuration_has_changed?
       existing_alternatives = load_alternatives_from_redis
       existing_goals = Split::GoalsCollection.new(@name).load_from_redis
       existing_metadata = load_metadata_from_redis
-      existing_alternatives != @alternatives.map(&:name) ||
+      existing_alternatives.map(&:to_s) != @alternatives.map(&:to_s) ||
         existing_goals != @goals ||
         existing_metadata != @metadata
     end

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -86,7 +86,7 @@ describe Split::Experiment do
       experiment.save
       experiment.save
       expect(Split.redis.exists('basket_text')).to be true
-      expect(Split.redis.lrange('basket_text', 0, -1)).to eq(['Basket', "Cart"])
+      expect(Split.redis.lrange('basket_text', 0, -1)).to eq(['{"Basket":1}', '{"Cart":1}'])
     end
 
     describe 'new record?' do

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -183,8 +183,7 @@ describe Split::Helper do
       ab_test('link_color', {'blue' => 0.01}, 'red' => 0.2)
       experiment = Split::ExperimentCatalog.find('link_color')
       expect(experiment.alternatives.map(&:name)).to eq(['blue', 'red'])
-      # TODO: persist alternative weights
-      # expect(experiment.alternatives.collect{|a| a.weight}).to eq([0.01, 0.2])
+      expect(experiment.alternatives.collect{|a| a.weight}).to eq([0.01, 0.2])
     end
 
     it "should only let a user participate in one experiment at a time" do

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -183,7 +183,7 @@ describe Split::Helper do
       ab_test('link_color', {'blue' => 0.01}, 'red' => 0.2)
       experiment = Split::ExperimentCatalog.find('link_color')
       expect(experiment.alternatives.map(&:name)).to eq(['blue', 'red'])
-      expect(experiment.alternatives.collect{|a| a.weight}).to eq([0.01, 0.2])
+      expect(experiment.alternatives.collect{|a| a.weight}).to match_array([0.01, 0.2])
     end
 
     it "should only let a user participate in one experiment at a time" do


### PR DESCRIPTION
Fix https://github.com/splitrb/split/issues/521 and TODO in `spec/helper_spec.rb` by adding alternative's weight with name to redis for weight persistence.
Please review this PR.