### PR TITLE
Handle correctly case when ab_finished is called before ab_test for a user

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -44,6 +44,7 @@ module Split
     end
 
     def finish_experiment(experiment, options = {:reset => true})
+      return false if active_experiments[experiment.name].nil?
       return true if experiment.has_winner?
       should_reset = experiment.resettable? && options[:reset]
       if ab_user[experiment.finished_key] && !should_reset


### PR DESCRIPTION
- [x] Don't change the `ab_user` state if the experiment about to finish is not active for this user
- [x] Tests added
--
Resolves #576 