### PR TITLE
Improve dashboard specs speed.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--profile

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -193,19 +193,17 @@ describe Split::Dashboard do
   end
 
   it "should display the start date" do
-    experiment_start_time = Time.parse('2011-07-07')
+    experiment_start_time = Time.now
+
     expect(Time).to receive(:now).at_least(:once).and_return(experiment_start_time)
     experiment
 
     get '/'
 
-    expect(last_response.body).to include('<small>2011-07-07</small>')
+    expect(last_response.body).to include("<small>#{experiment_start_time.strftime('%Y-%m-%d')}</small>")
   end
 
   it "should handle experiments without a start date" do
-    experiment_start_time = Time.parse('2011-07-07')
-    expect(Time).to receive(:now).at_least(:once).and_return(experiment_start_time)
-
     Split.redis.hdel(:experiment_start_times, experiment.name)
 
     get '/'

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -29,6 +29,10 @@ describe Split::Dashboard do
   let(:red_link) { link("red") }
   let(:blue_link) { link("blue") }
 
+  before(:each) do
+    Split.configuration.beta_probability_simulations = 1
+  end
+
   it "should respond to /" do
     get '/'
     expect(last_response).to be_ok


### PR DESCRIPTION
Calling calc_winning_alternatives takes too long with a high value on beta_probability_simulations.

That way we were able to gain ~10s locally. Probably more time on travis.