### PR TITLE
Suppress `warning: BigDecimal.new is deprecated;` in specs

### DIFF
--- a/spec/dashboard_helpers_spec.rb
+++ b/spec/dashboard_helpers_spec.rb
@@ -27,11 +27,11 @@ describe Split::DashboardHelpers do
 
     describe '#round' do
       it 'can round number strings' do
-        expect(round('3.1415')).to eq BigDecimal.new('3.14')
+        expect(round('3.1415')).to eq BigDecimal('3.14')
       end
 
       it 'can round number strings for precsion' do
-        expect(round('3.1415', 1)).to eq BigDecimal.new('3.1')
+        expect(round('3.1415', 1)).to eq BigDecimal('3.1')
       end
 
       it 'can handle invalid number strings' do


### PR DESCRIPTION
Replace `BigDecimal.new()` with `BigDecimal()` to suppress warnings in specs.
https://github.com/splitrb/split/pull/551 fixed this warning in codes, but didn't in specs. So, this PR fixes this warning in specs.

Following is a warning message.
```
warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```