### PR TITLE
Now returning correct experiment key without version

### DIFF
--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -62,7 +62,7 @@ module Split
     end
 
     def key_without_version(key)
-      key.split(/\:\d(?!\:)/)[0]
+      key.split(':').length > 2 ? key : key.split(/\:\d(?!\:)/)[0]
     end
   end
 end


### PR DESCRIPTION
Here I am splitting key based on colon i.e. ":". If it is an experiment finished key it will be have array length greater than 2, and method will be return the key as it is. Else it will remove the version number and return the experiment name. 