### PR TITLE
When loading active_experiments, it should not look into user's 'finished' keys

### DIFF
--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -41,7 +41,7 @@ module Split
 
     def active_experiments
       experiment_pairs = {}
-      user.keys.each do |key|
+      keys_without_finished(user.keys).each do |key|
         Metric.possible_experiments(key_without_version(key)).each do |experiment|
           if !experiment.has_winner?
             experiment_pairs[key_without_version(key)] = user[key]

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -555,6 +555,17 @@ describe Split::Helper do
       expect(active_experiments.first[0]).to eq "link_color"
     end
 
+    it 'should show versioned tests properly' do
+      10.times { experiment.reset }
+
+      alternative = ab_test(experiment.name, 'blue', 'red')
+      ab_finished(experiment.name, reset: false)
+
+      expect(experiment.version).to eq(10)
+      expect(active_experiments.count).to eq 1
+      expect(active_experiments).to eq({'link_color' => alternative })
+    end
+
     it 'should show multiple tests' do
       Split.configure do |config|
         config.allow_multiple_experiments = true


### PR DESCRIPTION
Fixes #580 

All calls for experiments keys on User should be gated with `keys_without_finished`. This method filters out all 'finished' keys.

The issue happened because `active_experiments` was loading all `user.keys`. And when calling `key_without_version` method with a 'finished' key with more than 9 versions. Example:

```
irb(main):012:0> key_without_version('exp:11:finished')
=> "exp"
irb(main):013:0> key_without_version('exp:1:finished')
=> "exp:1:finished"
```
It would end up overriding the value of an experiment with the 'exp:11:finished' value from the Storage, which is always 'true'.


