### PR TITLE
Remove `rubyforge_project` from gemspec

### DIFF
--- a/split.gemspec
+++ b/split.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.required_rubygems_version = '>= 2.0.0'
 
-  s.rubyforge_project = "split"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]


### PR DESCRIPTION
It's because rubyforge was EOL. I referred to https://github.com/rubygems/rubygems/pull/2798.

Following is a warning message for this.
```
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
```