### PR TITLE
Bump ruby versions because ruby 2.6.4/2.5.6/2.4.7 have been released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ rvm:
   - 2.1.10
   - 2.2.0
   - 2.2.2
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.4.7
+  - 2.5.6
+  - 2.6.4
 
 gemfile:
   - gemfiles/4.2.gemfile
@@ -53,7 +53,7 @@ matrix:
     gemfile: gemfiles/6.0.gemfile
   - rvm: 2.2.2
     gemfile: gemfiles/6.0.gemfile
-  - rvm: 2.4.5
+  - rvm: 2.4.7
     gemfile: gemfiles/6.0.gemfile
 
 before_install:


### PR DESCRIPTION
Bump ruby versions for travis because ruby 2.6.4/2.5.6/2.4.7 have been released.

Reference:
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-6-4-released/
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-5-6-released/
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-4-7-released/