### PR TITLE
Improve DualAdapter

### DIFF
--- a/lib/split/persistence/dual_adapter.rb
+++ b/lib/split/persistence/dual_adapter.rb
@@ -41,12 +41,25 @@ module Split
 
       def []=(key, value)
         @logged_in_adapter[key] = value if @logged_in
+        old_value = @logged_out_adapter[key]
         @logged_out_adapter[key] = value
+
+        decrement_participation(key, old_value) if decrement_participation?(old_value, value)
       end
 
       def delete(key)
         @logged_in_adapter.delete(key)
         @logged_out_adapter.delete(key)
+      end
+
+      private
+
+      def decrement_participation?(old_value, value)
+        !old_value.nil? && !value.nil? && old_value != value
+      end
+
+      def decrement_participation(key, value)
+        Split.redis.hincrby("#{key}:#{value}", 'participant_count', -1)
       end
     end
   end

--- a/lib/split/persistence/dual_adapter.rb
+++ b/lib/split/persistence/dual_adapter.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-require 'forwardable'
-
 module Split
   module Persistence
     class DualAdapter
-      extend Forwardable
-      def_delegators :@adapter, :keys, :[], :[]=, :delete
+      def self.with_config(options={})
+        self.config.merge!(options)
+        self
+      end
+
+      def self.config
+        @config ||= {}
+      end
 
       def initialize(context)
         if logged_in = self.class.config[:logged_in]
@@ -22,22 +26,28 @@ module Split
           raise "Please configure :logged_out_adapter"
         end
 
-        if logged_in.call(context)
-          @adapter = logged_in_adapter.new(context)
-        else
-          @adapter = logged_out_adapter.new(context)
-        end
+        @logged_in = logged_in.call(context)
+        @logged_in_adapter = logged_in_adapter.new(context)
+        @logged_out_adapter = logged_out_adapter.new(context)
       end
 
-      def self.with_config(options={})
-        self.config.merge!(options)
-        self
+      def keys
+        (@logged_in_adapter.keys + @logged_out_adapter.keys).uniq
       end
 
-      def self.config
-        @config ||= {}
+      def [](key)
+        @logged_in && @logged_in_adapter[key] || @logged_out_adapter[key]
       end
 
+      def []=(key, value)
+        @logged_in_adapter[key] = value if @logged_in
+        @logged_out_adapter[key] = value
+      end
+
+      def delete(key)
+        @logged_in_adapter.delete(key)
+        @logged_out_adapter.delete(key)
+      end
     end
   end
 end

--- a/spec/persistence/dual_adapter_spec.rb
+++ b/spec/persistence/dual_adapter_spec.rb
@@ -26,6 +26,7 @@ describe Split::Persistence::DualAdapter do
     it '#[]=' do
       expect(logged_in_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
       expect(logged_out_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
+      expect(logged_out_adapter_instance).to receive(:[]).with('my_key') { nil }
       subject['my_key'] = 'my_value'
     end
 
@@ -60,6 +61,7 @@ describe Split::Persistence::DualAdapter do
     it '#[]=' do
       expect_any_instance_of(logged_in_adapter).not_to receive(:[]=)
       expect(logged_out_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
+      expect(logged_out_adapter_instance).to receive(:[]).with('my_key') { nil }
       subject['my_key'] = 'my_value'
     end
 

--- a/spec/persistence/dual_adapter_spec.rb
+++ b/spec/persistence/dual_adapter_spec.rb
@@ -14,73 +14,149 @@ describe Split::Persistence::DualAdapter do
     Class.new.tap { |c| allow(c).to receive(:new) { logged_out_adapter_instance } }
   end
 
-  context 'when logged in' do
-    subject do
-      described_class.with_config(
-        logged_in: lambda { |context| true },
-        logged_in_adapter: logged_in_adapter,
-        logged_out_adapter: logged_out_adapter
-      ).new(context)
+  context 'when fallback_to_logged_out_adapter is false' do
+    context 'when logged in' do
+      subject do
+        described_class.with_config(
+          logged_in: lambda { |context| true },
+          logged_in_adapter: logged_in_adapter,
+          logged_out_adapter: logged_out_adapter,
+          fallback_to_logged_out_adapter: false
+        ).new(context)
+      end
+
+      it '#[]=' do
+        expect(logged_in_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
+        expect_any_instance_of(logged_out_adapter).not_to receive(:[]=)
+        subject['my_key'] = 'my_value'
+      end
+
+      it '#[]' do
+        expect(logged_in_adapter_instance).to receive(:[]).with('my_key') { 'my_value' }
+        expect_any_instance_of(logged_out_adapter).not_to receive(:[])
+        expect(subject['my_key']).to eq('my_value')
+      end
+
+      it '#delete' do
+        expect(logged_in_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
+        expect_any_instance_of(logged_out_adapter).not_to receive(:delete)
+        expect(subject.delete('my_key')).to eq('my_value')
+      end
+
+      it '#keys' do
+        expect(logged_in_adapter_instance).to receive(:keys) { ['my_value'] }
+        expect_any_instance_of(logged_out_adapter).not_to receive(:keys)
+        expect(subject.keys).to eq(['my_value'])
+      end
     end
 
-    it '#[]=' do
-      expect(logged_in_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
-      expect(logged_out_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
-      expect(logged_out_adapter_instance).to receive(:[]).with('my_key') { nil }
-      subject['my_key'] = 'my_value'
-    end
+    context 'when logged out' do
+      subject do
+        described_class.with_config(
+          logged_in: lambda { |context| false },
+          logged_in_adapter: logged_in_adapter,
+          logged_out_adapter: logged_out_adapter,
+          fallback_to_logged_out_adapter: false
+        ).new(context)
+      end
 
-    it '#[]' do
-      expect(logged_in_adapter_instance).to receive(:[]).with('my_key') { 'my_value' }
-      expect_any_instance_of(logged_out_adapter).not_to receive(:[])
-      expect(subject['my_key']).to eq('my_value')
-    end
+      it '#[]=' do
+        expect_any_instance_of(logged_in_adapter).not_to receive(:[]=)
+        expect(logged_out_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
+        subject['my_key'] = 'my_value'
+      end
 
-    it '#delete' do
-      expect(logged_in_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
-      expect(logged_out_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
-      expect(subject.delete('my_key')).to eq('my_value')
-    end
+      it '#[]' do
+        expect_any_instance_of(logged_in_adapter).not_to receive(:[])
+        expect(logged_out_adapter_instance).to receive(:[]).with('my_key') { 'my_value' }
+        expect(subject['my_key']).to eq('my_value')
+      end
 
-    it '#keys' do
-      expect(logged_in_adapter_instance).to receive(:keys) { ['my_value'] }
-      expect(logged_out_adapter_instance).to receive(:keys) { ['my_value', 'my_value2'] }
-      expect(subject.keys).to eq(['my_value', 'my_value2'])
+      it '#delete' do
+        expect_any_instance_of(logged_in_adapter).not_to receive(:delete)
+        expect(logged_out_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
+        expect(subject.delete('my_key')).to eq('my_value')
+      end
+
+      it '#keys' do
+        expect_any_instance_of(logged_in_adapter).not_to receive(:keys)
+        expect(logged_out_adapter_instance).to receive(:keys) { ['my_value', 'my_value2'] }
+        expect(subject.keys).to eq(['my_value', 'my_value2'])
+      end
     end
   end
 
-  context 'when logged out' do
-    subject do
-      described_class.with_config(
-        logged_in: lambda { |context| false },
-        logged_in_adapter: logged_in_adapter,
-        logged_out_adapter: logged_out_adapter
-      ).new(context)
+  context 'when fallback_to_logged_out_adapter is true' do
+    context 'when logged in' do
+      subject do
+        described_class.with_config(
+          logged_in: lambda { |context| true },
+          logged_in_adapter: logged_in_adapter,
+          logged_out_adapter: logged_out_adapter,
+          fallback_to_logged_out_adapter: true
+        ).new(context)
+      end
+
+      it '#[]=' do
+        expect(logged_in_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
+        expect(logged_out_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
+        expect(logged_out_adapter_instance).to receive(:[]).with('my_key') { nil }
+        subject['my_key'] = 'my_value'
+      end
+
+      it '#[]' do
+        expect(logged_in_adapter_instance).to receive(:[]).with('my_key') { 'my_value' }
+        expect_any_instance_of(logged_out_adapter).not_to receive(:[])
+        expect(subject['my_key']).to eq('my_value')
+      end
+
+      it '#delete' do
+        expect(logged_in_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
+        expect(logged_out_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
+        expect(subject.delete('my_key')).to eq('my_value')
+      end
+
+      it '#keys' do
+        expect(logged_in_adapter_instance).to receive(:keys) { ['my_value'] }
+        expect(logged_out_adapter_instance).to receive(:keys) { ['my_value', 'my_value2'] }
+        expect(subject.keys).to eq(['my_value', 'my_value2'])
+      end
     end
 
-    it '#[]=' do
-      expect_any_instance_of(logged_in_adapter).not_to receive(:[]=)
-      expect(logged_out_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
-      expect(logged_out_adapter_instance).to receive(:[]).with('my_key') { nil }
-      subject['my_key'] = 'my_value'
-    end
+    context 'when logged out' do
+      subject do
+        described_class.with_config(
+          logged_in: lambda { |context| false },
+          logged_in_adapter: logged_in_adapter,
+          logged_out_adapter: logged_out_adapter,
+          fallback_to_logged_out_adapter: true
+        ).new(context)
+      end
 
-    it '#[]' do
-      expect_any_instance_of(logged_in_adapter).not_to receive(:[])
-      expect(logged_out_adapter_instance).to receive(:[]).with('my_key') { 'my_value' }
-      expect(subject['my_key']).to eq('my_value')
-    end
+      it '#[]=' do
+        expect_any_instance_of(logged_in_adapter).not_to receive(:[]=)
+        expect(logged_out_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
+        expect(logged_out_adapter_instance).to receive(:[]).with('my_key') { nil }
+        subject['my_key'] = 'my_value'
+      end
 
-    it '#delete' do
-      expect(logged_in_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
-      expect(logged_out_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
-      expect(subject.delete('my_key')).to eq('my_value')
-    end
+      it '#[]' do
+        expect_any_instance_of(logged_in_adapter).not_to receive(:[])
+        expect(logged_out_adapter_instance).to receive(:[]).with('my_key') { 'my_value' }
+        expect(subject['my_key']).to eq('my_value')
+      end
 
-    it '#keys' do
-      expect(logged_in_adapter_instance).to receive(:keys) { ['my_value'] }
-      expect(logged_out_adapter_instance).to receive(:keys) { ['my_value', 'my_value2'] }
-      expect(subject.keys).to eq(['my_value', 'my_value2'])
+      it '#delete' do
+        expect(logged_in_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
+        expect(logged_out_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
+        expect(subject.delete('my_key')).to eq('my_value')
+      end
+
+      it '#keys' do
+        expect(logged_in_adapter_instance).to receive(:keys) { ['my_value'] }
+        expect(logged_out_adapter_instance).to receive(:keys) { ['my_value', 'my_value2'] }
+        expect(subject.keys).to eq(['my_value', 'my_value2'])
+      end
     end
   end
 

--- a/spec/persistence/dual_adapter_spec.rb
+++ b/spec/persistence/dual_adapter_spec.rb
@@ -1,102 +1,116 @@
 # frozen_string_literal: true
-require "spec_helper"
+
+require 'spec_helper'
 
 describe Split::Persistence::DualAdapter do
+  let(:context) { 'some context' }
 
-  let(:context){ "some context" }
-
-  let(:just_adapter){ Class.new }
-  let(:selected_adapter_instance){ double }
-  let(:selected_adapter){
-    c = Class.new
-    expect(c).to receive(:new){ selected_adapter_instance }
-    c
-  }
-  let(:not_selected_adapter){
-    c = Class.new
-    expect(c).not_to receive(:new)
-    c
-  }
-
-  shared_examples_for "forwarding calls" do
-    it "#[]=" do
-      expect(selected_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
-      expect_any_instance_of(not_selected_adapter).not_to receive(:[]=)
-      subject["my_key"] = "my_value"
-    end
-
-    it "#[]" do
-      expect(selected_adapter_instance).to receive(:[]).with('my_key'){'my_value'}
-      expect_any_instance_of(not_selected_adapter).not_to receive(:[])
-      expect(subject["my_key"]).to eq('my_value')
-    end
-
-    it "#delete" do
-      expect(selected_adapter_instance).to receive(:delete).with('my_key'){'my_value'}
-      expect_any_instance_of(not_selected_adapter).not_to receive(:delete)
-      expect(subject.delete("my_key")).to eq('my_value')
-    end
-
-    it "#keys" do
-      expect(selected_adapter_instance).to receive(:keys){'my_value'}
-      expect_any_instance_of(not_selected_adapter).not_to receive(:keys)
-      expect(subject.keys).to eq('my_value')
-    end
+  let(:logged_in_adapter_instance) { double }
+  let(:logged_in_adapter) do
+    Class.new.tap { |c| allow(c).to receive(:new) { logged_in_adapter_instance } }
+  end
+  let(:logged_out_adapter_instance) { double }
+  let(:logged_out_adapter) do
+    Class.new.tap { |c| allow(c).to receive(:new) { logged_out_adapter_instance } }
   end
 
-  context "when logged in" do
-    subject {
+  context 'when logged in' do
+    subject do
       described_class.with_config(
         logged_in: lambda { |context| true },
-        logged_in_adapter: selected_adapter,
-        logged_out_adapter: not_selected_adapter
-        ).new(context)
-    }
+        logged_in_adapter: logged_in_adapter,
+        logged_out_adapter: logged_out_adapter
+      ).new(context)
+    end
 
-    it_should_behave_like "forwarding calls"
+    it '#[]=' do
+      expect(logged_in_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
+      expect(logged_out_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
+      subject['my_key'] = 'my_value'
+    end
+
+    it '#[]' do
+      expect(logged_in_adapter_instance).to receive(:[]).with('my_key') { 'my_value' }
+      expect_any_instance_of(logged_out_adapter).not_to receive(:[])
+      expect(subject['my_key']).to eq('my_value')
+    end
+
+    it '#delete' do
+      expect(logged_in_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
+      expect(logged_out_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
+      expect(subject.delete('my_key')).to eq('my_value')
+    end
+
+    it '#keys' do
+      expect(logged_in_adapter_instance).to receive(:keys) { ['my_value'] }
+      expect(logged_out_adapter_instance).to receive(:keys) { ['my_value', 'my_value2'] }
+      expect(subject.keys).to eq(['my_value', 'my_value2'])
+    end
   end
 
-  context "when not logged in" do
-    subject {
+  context 'when logged out' do
+    subject do
       described_class.with_config(
         logged_in: lambda { |context| false },
-        logged_in_adapter: not_selected_adapter,
-        logged_out_adapter: selected_adapter
-        ).new(context)
-    }
+        logged_in_adapter: logged_in_adapter,
+        logged_out_adapter: logged_out_adapter
+      ).new(context)
+    end
 
-    it_should_behave_like "forwarding calls"
+    it '#[]=' do
+      expect_any_instance_of(logged_in_adapter).not_to receive(:[]=)
+      expect(logged_out_adapter_instance).to receive(:[]=).with('my_key', 'my_value')
+      subject['my_key'] = 'my_value'
+    end
+
+    it '#[]' do
+      expect_any_instance_of(logged_in_adapter).not_to receive(:[])
+      expect(logged_out_adapter_instance).to receive(:[]).with('my_key') { 'my_value' }
+      expect(subject['my_key']).to eq('my_value')
+    end
+
+    it '#delete' do
+      expect(logged_in_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
+      expect(logged_out_adapter_instance).to receive(:delete).with('my_key') { 'my_value' }
+      expect(subject.delete('my_key')).to eq('my_value')
+    end
+
+    it '#keys' do
+      expect(logged_in_adapter_instance).to receive(:keys) { ['my_value'] }
+      expect(logged_out_adapter_instance).to receive(:keys) { ['my_value', 'my_value2'] }
+      expect(subject.keys).to eq(['my_value', 'my_value2'])
+    end
   end
 
-  describe "when errors in config" do
-    before{
-      described_class.config.clear
-    }
-    let(:some_proc){ ->{} }
-    it "when no logged in adapter" do
+  describe 'when errors in config' do
+    before { described_class.config.clear }
+    let(:some_proc) { ->{} }
+
+    it 'when no logged in adapter' do
       expect{
         described_class.with_config(
           logged_in: some_proc,
-          logged_out_adapter: just_adapter
-          ).new(context)
+          logged_out_adapter: logged_out_adapter
+        ).new(context)
       }.to raise_error(StandardError, /:logged_in_adapter/)
     end
-    it "when no logged out adapter" do
+
+    it 'when no logged out adapter' do
       expect{
         described_class.with_config(
           logged_in: some_proc,
-          logged_in_adapter: just_adapter
-          ).new(context)
+          logged_in_adapter: logged_in_adapter
+        ).new(context)
       }.to raise_error(StandardError, /:logged_out_adapter/)
     end
-    it "when no logged in detector" do
+
+    it 'when no logged in detector' do
       expect{
         described_class.with_config(
-          logged_in_adapter: just_adapter,
-          logged_out_adapter: just_adapter
-          ).new(context)
+          logged_in_adapter: logged_in_adapter,
+          logged_out_adapter: logged_out_adapter
+        ).new(context)
       }.to raise_error(StandardError, /:logged_in$/)
     end
   end
-
 end


### PR DESCRIPTION
## Motivation: 
1. Given a user that hasn't been bucketed before in a running experiment.
2. When accessing a logged out page he/she is bucketed with version `A`.
3. When logging in

Expected Result:
Version `A` is still being shown. 

Actual Result:
The current `DualAdapter` will just leave it up to the `logged_in_adapter` which has no information of that user, and any version could be chosen.

Related issue https://github.com/splitrb/split/issues/483

## Notes:
Currently, the `DualAdapter` make use of the `logged_in_adapter` and `logged_out_adapter` in a  complete independent way. Because of that, the user won't have a consistent experience across logged in and logged out pages. This could also affect the conversions depending on how the experiment is set up. For example if the goal is in a logged in page, if someone was bucketed with two different versions when logged_in and logged_out, then the logged_out version will take no credit for the conversion but the logged_in version will take all of the credit.

With these changes the DualAdapter will use both adapters at the same time in a way such that we can make the UX consistent across logged in and logged out pages.