### PR TITLE
Update README.md to mention metadata key issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ and:
 ab_finished(:my_first_experiment)
 ```
 
-You can also add meta data for each experiment, very useful when you need more than an alternative name to change behaviour:
+You can also add meta data for each experiment, which is very useful when you need more than an alternative name to change behaviour:
 
 ```ruby
 Split.configure do |config|
@@ -600,6 +600,8 @@ or in views:
   <small><%= meta['text'] %></small>
 <% end %>
 ```
+
+The keys used in meta data should be Strings
 
 #### Metrics
 


### PR DESCRIPTION
This issue is related to https://github.com/splitrb/split/issues/185.

I ran into the same problem when creating an experiment that used symbols in the experiment's metadata configuration. This caused `Split::Experiment#experiment_configuration_has_changed?` to always return `true`, which reset the experiment. 😭 

```ruby
Split.configure do |config|
  config.experiments = {
    my_first_experiment: {
      alternatives: ["a", "b"],
      metadata: {
        "a" => { text: "Hello" },
        "b" => { text: "Hi" }
      }
    }    
  }
end
```

Maybe `split` should stringify metadata hash keys? I'm not convinced it should, but I do think this behavior should be noted in the README.