### PR TITLE
Fix ruby warnings

### DIFF
--- a/lib/split/alternative.rb
+++ b/lib/split/alternative.rb
@@ -75,7 +75,7 @@ module Split
       return field
     end
 
-    def set_completed_count (count, goal = nil)
+    def set_completed_count(count, goal = nil)
       field = set_field(goal)
       Split.redis.hset(key, field, count.to_i)
     end

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 module Split
   class Configuration
-    attr_accessor :bots
-    attr_accessor :robot_regex
     attr_accessor :ignore_ip_addresses
     attr_accessor :ignore_filter
     attr_accessor :db_failover
@@ -29,6 +27,9 @@ module Split
     attr_accessor :redis
 
     attr_reader :experiments
+
+    attr_writer :bots
+    attr_writer :robot_regex
 
     def bots
       @bots ||= {

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -2,12 +2,12 @@
 module Split
   class Experiment
     attr_accessor :name
-    attr_writer :algorithm
-    attr_accessor :resettable
     attr_accessor :goals
-    attr_accessor :alternatives
     attr_accessor :alternative_probabilities
     attr_accessor :metadata
+
+    attr_reader :alternatives
+    attr_reader :resettable
 
     DEFAULT_OPTIONS = {
       :resettable => true

--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -2,7 +2,7 @@
 module Split
   class Trial
     attr_accessor :experiment
-    attr_accessor :metadata
+    attr_writer :metadata
 
     def initialize(attrs = {})
       self.experiment   = attrs.delete(:experiment)

--- a/spec/encapsulated_helper_spec.rb
+++ b/spec/encapsulated_helper_spec.rb
@@ -33,7 +33,7 @@ describe Split::EncapsulatedHelper do
             static <%= alt %>
           <% end %>
         ERB
-        expect(template.result(binding)).to match /foo  static \d/
+        expect(template.result(binding)).to match(/foo  static \d/)
       end
 
     end

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -460,7 +460,7 @@ describe Split::Experiment do
       end
 
       it "should reset an experiment if it is loaded with different goals" do
-        same_experiment = same_but_different_goals
+        same_but_different_goals
         expect(Split::ExperimentCatalog.find("link_color").goals).to eq(["purchase", "refund"])
       end
 

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -449,9 +449,7 @@ describe Split::Experiment do
     }
 
     context "saving experiment" do
-      def same_but_different_goals
-        Split::ExperimentCatalog.find_or_create({'link_color' => ["purchase", "refund"]}, 'blue', 'red', 'green')
-      end
+      let(:same_but_different_goals) { Split::ExperimentCatalog.find_or_create({'link_color' => ["purchase", "refund"]}, 'blue', 'red', 'green') }
 
       before { experiment.save }
 

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -583,7 +583,7 @@ describe Split::Helper do
       end
       e = Split::ExperimentCatalog.find_or_create('def', '4', '5', '6')
       e.winner = '4'
-      alternative = ab_test('def', '4', '5', '6')
+      ab_test('def', '4', '5', '6')
       another_alternative = ab_test('ghi', '7', '8', '9')
       expect(active_experiments.count).to eq 1
       expect(active_experiments.first[0]).to eq "ghi"
@@ -1059,8 +1059,8 @@ describe Split::Helper do
 
   it 'should handle multiple experiments correctly' do
     experiment2 = Split::ExperimentCatalog.find_or_create('link_color2', 'blue', 'red')
-    alternative_name = ab_test('link_color', 'blue', 'red')
-    alternative_name2 = ab_test('link_color2', 'blue', 'red')
+    ab_test('link_color', 'blue', 'red')
+    ab_test('link_color2', 'blue', 'red')
     ab_finished('link_color2')
 
     experiment2.alternatives.each do |alt|


### PR DESCRIPTION
Avoid redefining accessor methods and ambiguous arguments.