### PR TITLE
Make dashboard pagination default "per" param configurable

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -25,7 +25,7 @@ module Split
     attr_accessor :beta_probability_simulations
     attr_accessor :winning_alternative_recalculation_interval
     attr_accessor :redis
-    attr_accessor :dashboard_pagination_default_per
+    attr_accessor :dashboard_pagination_default_per_page
 
     attr_reader :experiments
 
@@ -227,7 +227,7 @@ module Split
       @beta_probability_simulations = 10000
       @winning_alternative_recalculation_interval = 60 * 60 * 24 # 1 day
       @redis = ENV.fetch(ENV.fetch('REDIS_PROVIDER', 'REDIS_URL'), 'redis://localhost:6379')
-      @dashboard_pagination_default_per = 10
+      @dashboard_pagination_default_per_page = 10
     end
 
     def redis_url=(value)

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -25,6 +25,7 @@ module Split
     attr_accessor :beta_probability_simulations
     attr_accessor :winning_alternative_recalculation_interval
     attr_accessor :redis
+    attr_accessor :dashboard_pagination_default_per
 
     attr_reader :experiments
 
@@ -226,6 +227,7 @@ module Split
       @beta_probability_simulations = 10000
       @winning_alternative_recalculation_interval = 60 * 60 * 24 # 1 day
       @redis = ENV.fetch(ENV.fetch('REDIS_PROVIDER', 'REDIS_URL'), 'redis://localhost:6379')
+      @dashboard_pagination_default_per = 10
     end
 
     def redis_url=(value)

--- a/lib/split/dashboard/pagination_helpers.rb
+++ b/lib/split/dashboard/pagination_helpers.rb
@@ -4,8 +4,8 @@ require 'split/dashboard/paginator'
 module Split
   module DashboardPaginationHelpers
     def pagination_per
-      default_per = Split.configuration.dashboard_pagination_default_per
-      @pagination_per ||= (params[:per] || default_per).to_i
+      default_per_page = Split.configuration.dashboard_pagination_default_per_page
+      @pagination_per ||= (params[:per] || default_per_page).to_i
     end
 
     def page_number

--- a/lib/split/dashboard/pagination_helpers.rb
+++ b/lib/split/dashboard/pagination_helpers.rb
@@ -3,10 +3,9 @@ require 'split/dashboard/paginator'
 
 module Split
   module DashboardPaginationHelpers
-    DEFAULT_PER = 10
-
     def pagination_per
-      @pagination_per ||= (params[:per] || DEFAULT_PER).to_i
+      default_per = Split.configuration.dashboard_pagination_default_per
+      @pagination_per ||= (params[:per] || default_per).to_i
     end
 
     def page_number

--- a/spec/dashboard/pagination_helpers_spec.rb
+++ b/spec/dashboard/pagination_helpers_spec.rb
@@ -10,7 +10,9 @@ describe Split::DashboardPaginationHelpers do
     context 'when params empty' do
       let(:params) { Hash[] }
 
-      it 'returns 10' do
+      it 'returns the default (10)' do
+        default_per_page = Split.configuration.dashboard_pagination_default_per_page
+        expect(pagination_per).to eql default_per_page
         expect(pagination_per).to eql 10
       end
     end


### PR DESCRIPTION
Some people (like me) may prefer slower initial dashboard pageloads then
searching within the page vs. having to load many pages to try and find
the A/B test of interest to them.

Making the default "tests per page" parameter configurable gives that flexibility.

Test Plan:
rspec