### PR TITLE
Respect experiment defaults when loading experiments in initializer.

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -40,11 +40,15 @@ module Split
     end
 
     def set_alternatives_and_options(options)
-      self.alternatives = options[:alternatives]
-      self.goals = options[:goals]
-      self.resettable = options[:resettable]
-      self.algorithm = options[:algorithm]
-      self.metadata = options[:metadata]
+      options_with_defaults = DEFAULT_OPTIONS.merge(
+        options.reject { |k, v| v.nil? }
+      )
+
+      self.alternatives = options_with_defaults[:alternatives]
+      self.goals = options_with_defaults[:goals]
+      self.resettable = options_with_defaults[:resettable]
+      self.algorithm = options_with_defaults[:algorithm]
+      self.metadata = options_with_defaults[:metadata]
     end
 
     def extract_alternatives_from_options(options)

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -118,6 +118,23 @@ describe Split::Experiment do
       experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :resettable => false)
       expect(experiment.resettable).to be_falsey
     end
+    
+    context 'from configuration' do
+      let(:experiment_name) { :my_experiment }
+      let(:experiments) do
+        {
+          experiment_name => {
+            :alternatives => ['Control Opt', 'Alt one']
+          }
+        }
+      end
+
+      before { Split.configuration.experiments = experiments }
+      
+      it 'assigns default values to the experiment' do
+        expect(Split::Experiment.new(experiment_name).resettable).to eq(true)
+      end
+    end
   end
 
   describe 'persistent configuration' do


### PR DESCRIPTION
Addresses issue https://github.com/splitrb/split/issues/598