### PR TITLE
Reference ActionController directly when including split helpers

### DIFF
--- a/lib/split/engine.rb
+++ b/lib/split/engine.rb
@@ -4,10 +4,10 @@ module Split
     initializer "split" do |app|
       if Split.configuration.include_rails_helper
         ActiveSupport.on_load(:action_controller) do
-          include Split::Helper
-          helper Split::Helper
-          include Split::CombinedExperimentsHelper
-          helper Split::CombinedExperimentsHelper
+          ::ActionController::Base.send :include, Split::Helper
+          ::ActionController::Base.helper Split::Helper
+          ::ActionController::Base.send :include, Split::CombinedExperimentsHelper
+          ::ActionController::Base.helper Split::CombinedExperimentsHelper
         end
       end
     end


### PR DESCRIPTION
Fixes #601 