### PR TITLE
Fix #max_experiments_reached? when using allow_multiple_experiments=control

### DIFF
--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -27,7 +27,8 @@ module Split
     def max_experiments_reached?(experiment_key)
       if Split.configuration.allow_multiple_experiments == 'control'
         experiments = active_experiments
-        count_control = experiments.count {|k,v| k == experiment_key || v == 'control'}
+        experiment_key_without_version = key_without_version(experiment_key)
+        count_control = experiments.count {|k,v| k == experiment_key_without_version || v == 'control'}
         experiments.size > count_control
       else
         !Split.configuration.allow_multiple_experiments &&

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -229,18 +229,30 @@ describe Split::Helper do
 
       context "when user already has experiment" do
         let(:mock_user){ Split::User.new(self, {'test_0' => 'test-alt'}) }
-        before{
+
+        before do
           Split.configure do |config|
             config.allow_multiple_experiments = 'control'
           end
+
           Split::ExperimentCatalog.find_or_initialize('test_0', 'control', 'test-alt').save
           Split::ExperimentCatalog.find_or_initialize('test_1', 'control', 'test-alt').save
-        }
+        end
 
         it "should restore previously selected alternative" do
           expect(ab_user.active_experiments.size).to eq 1
           expect(ab_test(:test_0, {'control' => 100}, {"test-alt" => 1})).to eq 'test-alt'
           expect(ab_test(:test_0, {'control' => 1}, {"test-alt" => 100})).to eq 'test-alt'
+        end
+
+        it "should select the correct alternatives after experiment resets" do
+          experiment = Split::ExperimentCatalog.find(:test_0)
+          experiment.reset
+          mock_user[experiment.key] = 'test-alt'
+
+          expect(ab_user.active_experiments.size).to eq 1
+          expect(ab_test(:test_0, {'control' => 100}, {"test-alt" => 1})).to eq 'test-alt'
+          expect(ab_test(:test_0, {'control' => 0}, {"test-alt" => 100})).to eq 'test-alt'
         end
 
         it "lets override existing choice" do


### PR DESCRIPTION
When using allow_multiple_experiments=control Split only allows one
experiment with an alternative other than 'control'.

Split::User#max_experiments_reached? checks for that looping through all
experiments. As Split::User#active_experiments drop the experiment
version we also need to do that here to be able to check properly.

Fixes #612 