### PR TITLE
Introduce enable/disable experiment cohorting

### DIFF
--- a/lib/split/dashboard.rb
+++ b/lib/split/dashboard.rb
@@ -65,6 +65,17 @@ module Split
       redirect url('/')
     end
 
+    post '/update_cohorting' do
+      @experiment = Split::ExperimentCatalog.find(params[:experiment])
+      case params[:cohorting_action].downcase
+      when "enable"
+        @experiment.enable_cohorting
+      when "disable"
+        @experiment.disable_cohorting
+      end
+      redirect url('/')
+    end
+
     delete '/experiment' do
       @experiment = Split::ExperimentCatalog.find(params[:experiment])
       @experiment.delete

--- a/lib/split/dashboard/public/dashboard.js
+++ b/lib/split/dashboard/public/dashboard.js
@@ -22,3 +22,13 @@ function confirmReopen() {
   var agree = confirm("This will reopen the experiment. Are you sure?");
   return agree ? true : false;
 }
+
+function confirmEnableCohorting(){
+  var agree = confirm("This will enable the cohorting of the experiment. Are you sure?");
+  return agree ? true : false;
+}
+
+function confirmDisableCohorting(){
+  var agree = confirm("This will disable the cohorting of the experiment. Note: Existing participants will continue to receive their alternative and may continue to convert. Are you sure?");
+  return agree ? true : false;
+}

--- a/lib/split/dashboard/public/style.css
+++ b/lib/split/dashboard/public/style.css
@@ -326,3 +326,8 @@ a.button.green:focus, button.green:focus, input[type="submit"].green:focus {
   display: inline-block;
   padding: 5px;
 }
+
+.divider {
+  display: inline-block;
+  margin-left: 10px;
+}

--- a/lib/split/dashboard/views/_controls.erb
+++ b/lib/split/dashboard/views/_controls.erb
@@ -1,3 +1,15 @@
+<% if experiment.cohorting_disabled? %>
+  <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmEnableCohorting()">
+    <input type="hidden" name="cohorting_action" value="enable">
+    <input type="submit" value="Enable Cohorting" class="green">
+  </form>
+<% else %>
+  <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmDisableCohorting()">
+    <input type="hidden" name="cohorting_action" value="disable">
+    <input type="submit" value="Disable Cohorting" class="red">
+  </form>
+<% end %>
+<span class="divider">|</span>
 <% if experiment.has_winner? %>
   <form action="<%= url "/reopen?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReopen()">
     <input type="submit" value="Reopen Experiment">

--- a/lib/split/dashboard/views/_controls.erb
+++ b/lib/split/dashboard/views/_controls.erb
@@ -1,20 +1,21 @@
-<% if experiment.cohorting_disabled? %>
-  <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmEnableCohorting()">
-    <input type="hidden" name="cohorting_action" value="enable">
-    <input type="submit" value="Enable Cohorting" class="green">
-  </form>
-<% else %>
-  <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmDisableCohorting()">
-    <input type="hidden" name="cohorting_action" value="disable">
-    <input type="submit" value="Disable Cohorting" class="red">
-  </form>
-<% end %>
-<span class="divider">|</span>
 <% if experiment.has_winner? %>
   <form action="<%= url "/reopen?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReopen()">
     <input type="submit" value="Reopen Experiment">
   </form>
+<% else %>
+  <% if experiment.cohorting_disabled? %>
+    <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmEnableCohorting()">
+      <input type="hidden" name="cohorting_action" value="enable">
+      <input type="submit" value="Enable Cohorting" class="green">
+    </form>
+  <% else %>
+    <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmDisableCohorting()">
+      <input type="hidden" name="cohorting_action" value="disable">
+      <input type="submit" value="Disable Cohorting" class="red">
+    </form>
+  <% end %>
 <% end %>
+<span class="divider">|</span>
 <% if experiment.start_time %>
   <form action="<%= url "/reset?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReset()">
     <input type="submit" value="Reset Data">

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -235,6 +235,7 @@ module Split
       end
       reset_winner
       redis.srem(:experiments, name)
+      redis.hdel(experiment_config_key, :cohorting)
       remove_experiment_configuration
       Split.configuration.on_experiment_delete.call(self)
       increment_version
@@ -385,6 +386,19 @@ module Split
                 name + "-" + goal
               end
       js_id.gsub('/', '--')
+    end
+
+    def cohorting_disabled?
+      value = redis.hget(experiment_config_key, :cohorting)
+      value.nil? ? false : value.downcase == "true"
+    end
+
+    def disable_cohorting
+      redis.hset(experiment_config_key, :cohorting, true)
+    end
+
+    def enable_cohorting
+      redis.hset(experiment_config_key, :cohorting, false)
     end
 
     protected

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -235,7 +235,7 @@ module Split
       end
       reset_winner
       redis.srem(:experiments, name)
-      redis.hdel(experiment_config_key, :cohorting)
+      remove_experiment_cohorting
       remove_experiment_configuration
       Split.configuration.on_experiment_delete.call(self)
       increment_version
@@ -389,15 +389,19 @@ module Split
     end
 
     def cohorting_disabled?
-      value = redis.hget(experiment_config_key, :cohorting)
-      value.nil? ? false : value.downcase == "true"
+      @cohorting_disabled ||= begin
+        value = redis.hget(experiment_config_key, :cohorting)
+        value.nil? ? false : value.downcase == "true"
+      end
     end
 
     def disable_cohorting
+      @cohorting_disabled = true
       redis.hset(experiment_config_key, :cohorting, true)
     end
 
     def enable_cohorting
+      @cohorting_disabled = false
       redis.hset(experiment_config_key, :cohorting, false)
     end
 
@@ -481,6 +485,11 @@ module Split
 
     def goals_collection
       Split::GoalsCollection.new(@name, @goals)
+    end
+
+    def remove_experiment_cohorting
+      @cohorting_disabled = false
+      redis.hdel(experiment_config_key, :cohorting)
     end
   end
 end

--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -85,9 +85,11 @@ module Split
         end
       end
 
-      @user[@experiment.key] = alternative.name unless @experiment.has_winner? || !should_store_alternative? || (new_participant && @experiment.cohorting_disabled?)
+      new_participant_and_cohorting_disabled = new_participant && @experiment.cohorting_disabled?
+
+      @user[@experiment.key] = alternative.name unless @experiment.has_winner? || !should_store_alternative? || new_participant_and_cohorting_disabled
       @alternative_choosen = true
-      run_callback context, Split.configuration.on_trial unless @options[:disabled] || Split.configuration.disabled? || (new_participant && @experiment.cohorting_disabled?) 
+      run_callback context, Split.configuration.on_trial unless @options[:disabled] || Split.configuration.disabled? || new_participant_and_cohorting_disabled
       alternative
     end
 

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -161,6 +161,28 @@ describe Split::Dashboard do
     end
   end
 
+  describe "update cohorting" do
+    it "calls enable of cohorting when action is enable" do
+      post "/update_cohorting?experiment=#{experiment.name}", { "cohorting_action": "enable" }
+
+      expect(experiment.cohorting_disabled?).to eq false
+    end
+
+    it "calls disable of cohorting when action is disable" do
+      post "/update_cohorting?experiment=#{experiment.name}", { "cohorting_action": "disable" }
+      
+      expect(experiment.cohorting_disabled?).to eq true
+    end
+
+    it "calls neither enable or disable cohorting when passed invalid action" do
+      previous_value = experiment.cohorting_disabled?
+
+      post "/update_cohorting?experiment=#{experiment.name}", { "cohorting_action": "other" }
+
+      expect(experiment.cohorting_disabled?).to eq previous_value
+    end
+  end
+
   it "should reset an experiment" do
     red_link.participant_count = 5
     blue_link.participant_count = 7

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -223,8 +223,14 @@ describe Split::Experiment do
       experiment.delete
       expect(experiment.start_time).to be_nil
     end
-  end
 
+    it "should default cohorting back to false" do
+      experiment.disable_cohorting
+      expect(experiment.cohorting_disabled?).to eq(true)
+      experiment.delete
+      expect(experiment.cohorting_disabled?).to eq(false)
+    end
+  end
 
   describe 'winner' do
     it "should have no winner initially" do
@@ -389,6 +395,34 @@ describe Split::Experiment do
         expect(experiment.next_alternative.name).to eq('blue')
         expect(experiment.next_alternative.name).to eq('blue')
       end
+    end
+  end
+
+  describe "#cohorting_disabled?" do
+    it "returns false when nothing has been configured" do
+      expect(experiment.cohorting_disabled?).to eq false
+    end
+
+    it "returns true when enable_cohorting is performed" do
+      experiment.enable_cohorting
+      expect(experiment.cohorting_disabled?).to eq false
+    end
+
+    it "returns false when nothing has been configured" do
+      experiment.disable_cohorting
+      expect(experiment.cohorting_disabled?).to eq true
+    end
+  end
+
+  describe "#disable_cohorting" do
+    it "saves a new key in redis" do
+      expect(experiment.disable_cohorting).to eq true
+    end
+  end
+
+  describe "#enable_cohorting" do
+    it "saves a new key in redis" do
+      expect(experiment.enable_cohorting).to eq true
     end
   end
 

--- a/spec/trial_spec.rb
+++ b/spec/trial_spec.rb
@@ -198,6 +198,33 @@ describe Split::Trial do
         expect(trial.alternative.name).to_not be_empty
         Split.configuration.on_trial_choose = nil
       end
+
+      it "assigns user to an alternative" do
+        trial.choose! context
+
+        expect(alternatives).to include(user[experiment.name])
+      end
+
+      context "when cohorting is disabled" do
+        before(:each) { allow(experiment).to receive(:cohorting_disabled?).and_return(true) }
+
+        it "picks the control and does not run on_trial callbacks" do
+          Split.configuration.on_trial = :on_trial_callback
+
+          expect(experiment).to_not receive(:next_alternative)
+          expect(context).not_to receive(:on_trial_callback)
+          expect_alternative(trial, 'basket')
+
+          Split.configuration.enabled = true
+          Split.configuration.on_trial = nil
+        end
+
+        it "user is not assigned an alternative" do
+          trial.choose! context
+
+          expect(user[experiment]).to eq(nil)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### What problem does this solve?
Disabling Cohorting: Allow existing registered participants time to convert while no longer accepting new participants into the experiment. New participants will be given the control will be given the control and will not be recorded as being apart of the experiment.

### Why is this useful?
- Gives implementers the ability to soft close experiments, allowing shifting new participants into other experiments before concluding the result of the experiment (selecting a winner).
- Allows for better accuracy of data, ~> allows participants the chance to convert if they engaged late before the end of the experiment.

### How does this solve it?
- Adds enable/disable button to the dashboard
- Provides a brief alert description describing the resulting behaviour when performed.
- Adds functions to the experiment object to check and mutate the flag stored in redis.
- Deletion of the experiment will result in the deletion of the flag (resetting it back to its default state = cohorting enabled)
- Continues to perform appropriate callbacks if the user is already an existing participant to the experiment.
- Performs no callbacks if the participant is first entering the experiment for the first time when cohorting is disabled.
- existing overrides and disables take precedence

![Screen Shot 2020-04-23 at 10 20 26 PM](https://user-images.githubusercontent.com/58270715/80239257-c3c29a80-8614-11ea-9327-a66bf6bfc892.png)
