### PR TITLE
Replace usage of SimpleRandom with RubyStats

### DIFF
--- a/lib/split/algorithms/whiplash.rb
+++ b/lib/split/algorithms/whiplash.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # A multi-armed bandit implementation inspired by
 # @aaronsw and victorykit/whiplash
-require 'simple-random'
+require 'rubystats'
 
 module Split
   module Algorithms
@@ -16,7 +16,7 @@ module Split
         def arm_guess(participants, completions)
           a = [participants, 0].max
           b = [participants-completions, 0].max
-          s = SimpleRandom.new; s.set_seed; s.beta(a+fairness_constant, b+fairness_constant)
+          Rubystats::BetaDistribution.new(a+fairness_constant, b+fairness_constant).rng
         end
 
         def best_guess(alternatives)

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+require 'rubystats'
+
 module Split
   class Experiment
     attr_accessor :name
@@ -354,17 +357,13 @@ module Split
     end
 
     def calc_simulated_conversion_rates(beta_params)
-      # initialize a random variable (from which to simulate conversion rates ~beta-distributed)
-      rand = SimpleRandom.new
-      rand.set_seed
-
       simulated_cr_hash = {}
 
       # create a hash which has the conversion rate pulled from each alternative's beta distribution
       beta_params.each do |alternative, params|
         alpha = params[0]
         beta = params[1]
-        simulated_conversion_rate = rand.beta(alpha, beta)
+        simulated_conversion_rate = Rubystats::BetaDistribution.new(alpha, beta).rng
         simulated_cr_hash[alternative] = simulated_conversion_rate
       end
 

--- a/split.gemspec
+++ b/split.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'redis',           '>= 2.1'
   s.add_dependency 'sinatra',         '>= 1.2.6'
-  s.add_dependency 'simple-random',   '>= 0.9.3'
+  s.add_dependency 'rubystats',       '>= 0.3.0'
 
   s.add_development_dependency 'bundler',     '>= 1.17'
   s.add_development_dependency 'simplecov',   '~> 0.15'


### PR DESCRIPTION
This replaces the usage of the Beta Distribution RNG parts.

No behavior was changed by this.