### PR TITLE
Removed repeated loading from config

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -18,21 +18,7 @@ module Split
 
       @name = name.to_s
 
-      alternatives = extract_alternatives_from_options(options)
-
-      if alternatives.empty? && (exp_config = Split.configuration.experiment_for(name))
-        options = {
-          alternatives: load_alternatives_from_configuration,
-          goals: Split::GoalsCollection.new(@name).load_from_configuration,
-          metadata: load_metadata_from_configuration,
-          resettable: exp_config[:resettable],
-          algorithm: exp_config[:algorithm]
-        }
-      else
-        options[:alternatives] = alternatives
-      end
-
-      set_alternatives_and_options(options)
+      extract_alternatives_from_options(options)
     end
 
     def self.finished_key(key)


### PR DESCRIPTION
### What problem does this solve?
Removes code that is not called(?) and has already been addressed in `extract_alternatives_from_options()`. More specifically the function checks whether or not the alternatives were passed via the options as params, which will then already proceeds to try loading them from Split.configuration.experiments ~> no reason for the outer `initialize()` to try to do the same.

### Why is this useful?
- Makes it easier to read

### How does this solve it?
- Removes code from initialize
