### PR TITLE
ab_test must return metadata on error or if split is disabled/excluded user

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -32,8 +32,8 @@ module Split
       end
 
       if block_given?
-        metadata = trial ? trial.metadata : {}
-        yield(alternative, metadata)
+        metadata = experiment.metadata[alternative] if experiment.metadata
+        yield(alternative, metadata || {})
       else
         alternative
       end

--- a/spec/encapsulated_helper_spec.rb
+++ b/spec/encapsulated_helper_spec.rb
@@ -21,7 +21,7 @@ describe Split::EncapsulatedHelper do
     end
 
     it "calls the block with selected alternative" do
-      expect{|block| ab_test('link_color', 'red', 'red', &block) }.to yield_with_args('red', nil)
+      expect{|block| ab_test('link_color', 'red', 'red', &block) }.to yield_with_args('red', {})
     end
 
     context "inside a view" do

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -277,33 +277,63 @@ describe Split::Helper do
   end
 
   describe 'metadata' do
-    before do
-      Split.configuration.experiments = {
-        :my_experiment => {
-          :alternatives => ["one", "two"],
-          :resettable => false,
-          :metadata => { 'one' => 'Meta1', 'two' => 'Meta2' }
+    context 'is defined' do
+      before do
+        Split.configuration.experiments = {
+          :my_experiment => {
+            :alternatives => ["one", "two"],
+            :resettable => false,
+            :metadata => { 'one' => 'Meta1', 'two' => 'Meta2' }
+          }
         }
-      }
-    end
-
-    it 'should be passed to helper block' do
-      @params = { 'ab_test' => { 'my_experiment' => 'one' } }
-      expect(ab_test('my_experiment')).to eq 'one'
-      expect(ab_test('my_experiment') do |alternative, meta|
-        meta
-      end).to eq('Meta1')
-    end
-
-    it 'should pass empty hash to helper block if library disabled' do
-      Split.configure do |config|
-        config.enabled = false
       end
 
-      expect(ab_test('my_experiment')).to eq 'one'
-      expect(ab_test('my_experiment') do |_, meta|
-        meta
-      end).to eq({})
+      it 'should be passed to helper block' do
+        @params = { 'ab_test' => { 'my_experiment' => 'two' } }
+        expect(ab_test('my_experiment')).to eq 'two'
+        expect(ab_test('my_experiment') do |alternative, meta|
+          meta
+        end).to eq('Meta2')
+      end
+
+      it 'should pass control metadata helper block if library disabled' do
+        Split.configure do |config|
+          config.enabled = false
+        end
+
+        expect(ab_test('my_experiment')).to eq 'one'
+        expect(ab_test('my_experiment') do |_, meta|
+          meta
+        end).to eq('Meta1')
+      end
+    end
+
+    context 'is not defined' do
+      before do
+        Split.configuration.experiments = {
+          :my_experiment => {
+            :alternatives => ["one", "two"],
+            :resettable => false,
+            :metadata => nil
+          }
+        }
+      end
+
+      it 'should be passed to helper block' do
+        expect(ab_test('my_experiment') do |alternative, meta|
+          meta
+        end).to eq({})
+      end
+
+      it 'should pass control metadata helper block if library disabled' do
+        Split.configure do |config|
+          config.enabled = false
+        end
+
+        expect(ab_test('my_experiment') do |_, meta|
+          meta
+        end).to eq({})
+      end
     end
   end
 


### PR DESCRIPTION
Split returns 'control' when disabled/excluded users/redis connection issues.

Before: Split yield {} as metadata even if there was one available.
After: If there's a metadata associated with the alternative, split will yield the metadata.

This will also make the behavior consistent between all scenarios. Unless the metadata is not defined on the configuration files.

ExperimentCatalog.find_or_initialize does not make any redis calls, so it's safe to use 'experiment' because it loads data from configuration.

Fixes #618