### PR TITLE
Bump minimum required redis to 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 2.6.6
   - 2.7.1
 
+services:
+  - redis-server
+
 gemfile:
   - gemfiles/5.0.gemfile
   - gemfiles/5.1.gemfile

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -94,7 +94,7 @@ module Split
     end
 
     def new_record?
-      !redis.exists(name)
+      !redis.exists?(name)
     end
 
     def ==(obj)

--- a/lib/split/experiment_catalog.rb
+++ b/lib/split/experiment_catalog.rb
@@ -13,7 +13,7 @@ module Split
     end
 
     def self.find(name)
-      return unless Split.redis.exists(name)
+      return unless Split.redis.exists?(name)
       Experiment.new(name).tap { |exp| exp.load_from_redis }
     end
 

--- a/spec/alternative_spec.rb
+++ b/spec/alternative_spec.rb
@@ -126,7 +126,7 @@ describe Split::Alternative do
 
   it "should save to redis" do
     alternative.save
-    expect(Split.redis.exists('basket_text:Basket')).to be true
+    expect(Split.redis.exists?('basket_text:Basket')).to be true
   end
 
   it "should increment participation count" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -240,6 +240,7 @@ describe Split::Configuration do
       it "should use the ENV variable" do
         ENV['REDIS_URL'] = "env_redis_url"
         expect(Split::Configuration.new.redis).to eq("env_redis_url")
+        ENV.delete('REDIS_URL')
       end
     end
   end

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -414,18 +414,6 @@ describe Split::Experiment do
     end
   end
 
-  describe "#disable_cohorting" do
-    it "saves a new key in redis" do
-      expect(experiment.disable_cohorting).to eq true
-    end
-  end
-
-  describe "#enable_cohorting" do
-    it "saves a new key in redis" do
-      expect(experiment.enable_cohorting).to eq true
-    end
-  end
-
   describe 'changing an existing experiment' do
     def same_but_different_alternative
       Split::ExperimentCatalog.find_or_create('link_color', 'blue', 'yellow', 'orange')

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -37,7 +37,7 @@ describe Split::Experiment do
 
     it "should save to redis" do
       experiment.save
-      expect(Split.redis.exists('basket_text')).to be true
+      expect(Split.redis.exists?('basket_text')).to be true
     end
 
     it "should save the start time to redis" do
@@ -85,7 +85,7 @@ describe Split::Experiment do
     it "should not create duplicates when saving multiple times" do
       experiment.save
       experiment.save
-      expect(Split.redis.exists('basket_text')).to be true
+      expect(Split.redis.exists?('basket_text')).to be true
       expect(Split.redis.lrange('basket_text', 0, -1)).to eq(['{"Basket":1}', '{"Cart":1}'])
     end
 
@@ -197,7 +197,7 @@ describe Split::Experiment do
       experiment.save
 
       experiment.delete
-      expect(Split.redis.exists('link_color')).to be false
+      expect(Split.redis.exists?('link_color')).to be false
       expect(Split::ExperimentCatalog.find('link_color')).to be_nil
     end
 

--- a/spec/goals_collection_spec.rb
+++ b/spec/goals_collection_spec.rb
@@ -48,7 +48,7 @@ describe Split::GoalsCollection do
       goals_collection.save
 
       goals_collection.delete
-      expect(Split.redis.exists(goals_key)).to be false
+      expect(Split.redis.exists?(goals_key)).to be false
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,17 +13,15 @@ require 'yaml'
 
 Dir['./spec/support/*.rb'].each { |f| require f }
 
-require "fakeredis"
-
-G_fakeredis = Redis.new
-
 module GlobalSharedContext
   extend RSpec::SharedContext
   let(:mock_user){ Split::User.new(double(session: {})) }
+
   before(:each) do
     Split.configuration = Split::Configuration.new
-    Split.redis = G_fakeredis
-    Split.redis.flushall
+    Split.redis = Redis.new
+    Split.redis.select(10)
+    Split.redis.flushdb
     @ab_user = mock_user
     params = nil
   end

--- a/split.gemspec
+++ b/split.gemspec
@@ -39,6 +39,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',        '~> 13'
   s.add_development_dependency 'rspec',       '~> 3.7'
   s.add_development_dependency 'pry',         '~> 0.10'
-  s.add_development_dependency 'fakeredis',   '~> 0.7'
   s.add_development_dependency 'rails',       '>= 5.0'
 end

--- a/split.gemspec
+++ b/split.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency 'redis',           '>= 2.1'
+  s.add_dependency 'redis',           '>= 4.2'
   s.add_dependency 'sinatra',         '>= 1.2.6'
   s.add_dependency 'rubystats',       '>= 0.3.0'
 


### PR DESCRIPTION
redis-rb 2.2 was released long ago, it's time to update the minimum required deps.

Also drops fakeredis, so we can test using real Redis instances on CI.
