### PR TITLE
Simplify RedisInterface usage when persisting Experiment alternatives

### DIFF
--- a/lib/split/redis_interface.rb
+++ b/lib/split/redis_interface.rb
@@ -19,7 +19,7 @@ module Split
     end
 
     def add_to_set(set_name, value)
-      redis.sadd(set_name, value) unless redis.sismember(set_name, value)
+      redis.sadd(set_name, value)
     end
 
     private

--- a/lib/split/redis_interface.rb
+++ b/lib/split/redis_interface.rb
@@ -31,10 +31,6 @@ module Split
       redis.llen(list_name)
     end
 
-    def remove_last_item_from_list(list_name)
-      redis.rpop(list_name)
-    end
-
     def make_list_length(list_name, new_length)
       redis.ltrim(list_name, 0, new_length - 1)
     end

--- a/lib/split/redis_interface.rb
+++ b/lib/split/redis_interface.rb
@@ -7,32 +7,15 @@ module Split
     end
 
     def persist_list(list_name, list_values)
-      max_index = list_length(list_name) - 1
-      list_values.each_with_index do |value, index|
-        if index > max_index
-          add_to_list(list_name, value)
-        else
-          set_list_index(list_name, index, value)
+      if list_values.length > 0
+        redis.multi do |multi|
+          tmp_list = "#{list_name}_tmp"
+          multi.rpush(tmp_list, list_values)
+          multi.rename(tmp_list, list_name)
         end
       end
-      make_list_length(list_name, list_values.length)
+
       list_values
-    end
-
-    def add_to_list(list_name, value)
-      redis.rpush(list_name, value)
-    end
-
-    def set_list_index(list_name, index, value)
-      redis.lset(list_name, index, value)
-    end
-
-    def list_length(list_name)
-      redis.llen(list_name)
-    end
-
-    def make_list_length(list_name, new_length)
-      redis.ltrim(list_name, 0, new_length - 1)
     end
 
     def add_to_set(set_name, value)

--- a/spec/redis_interface_spec.rb
+++ b/spec/redis_interface_spec.rb
@@ -70,20 +70,6 @@ describe Split::RedisInterface do
     end
   end
 
-  describe '#remove_last_item_from_list' do
-    subject(:remove_last_item_from_list) do
-      interface.add_to_list(list_name, 'y')
-      interface.add_to_list(list_name, 'z')
-      interface.remove_last_item_from_list(list_name)
-    end
-
-    specify do
-      remove_last_item_from_list
-      expect(Split.redis.lindex(list_name, 0)).to eq 'y'
-      expect(Split.redis.llen(list_name)).to eq 1
-    end
-  end
-
   describe '#make_list_length' do
     subject(:make_list_length) do
       interface.add_to_list(list_name, 'y')

--- a/spec/redis_interface_spec.rb
+++ b/spec/redis_interface_spec.rb
@@ -29,61 +29,6 @@ describe Split::RedisInterface do
     end
   end
 
-  describe '#add_to_list' do
-    subject(:add_to_list) do
-      interface.add_to_list(list_name, 'y')
-      interface.add_to_list(list_name, 'z')
-    end
-
-    specify do
-      add_to_list
-      expect(Split.redis.lindex(list_name, 0)).to eq 'y'
-      expect(Split.redis.lindex(list_name, 1)).to eq 'z'
-      expect(Split.redis.llen(list_name)).to eq 2
-    end
-  end
-
-  describe '#set_list_index' do
-    subject(:set_list_index) do
-      interface.add_to_list(list_name, 'y')
-      interface.add_to_list(list_name, 'z')
-      interface.set_list_index(list_name, 0, 'a')
-    end
-
-    specify do
-      set_list_index
-      expect(Split.redis.lindex(list_name, 0)).to eq 'a'
-      expect(Split.redis.lindex(list_name, 1)).to eq 'z'
-      expect(Split.redis.llen(list_name)).to eq 2
-    end
-  end
-
-  describe '#list_length' do
-    subject(:list_length) do
-      interface.add_to_list(list_name, 'y')
-      interface.add_to_list(list_name, 'z')
-      interface.list_length(list_name)
-    end
-
-    specify do
-      expect(list_length).to eq 2
-    end
-  end
-
-  describe '#make_list_length' do
-    subject(:make_list_length) do
-      interface.add_to_list(list_name, 'y')
-      interface.add_to_list(list_name, 'z')
-      interface.make_list_length(list_name, 1)
-    end
-
-    specify do
-      make_list_length
-      expect(Split.redis.lindex(list_name, 0)).to eq 'y'
-      expect(Split.redis.llen(list_name)).to eq 1
-    end
-  end
-
   describe '#add_to_set' do
     subject(:add_to_set) do
       interface.add_to_set(set_name, 'something')


### PR DESCRIPTION
When persisting a list several calls are being made to ensure that each element gets the correct index.

Instead of dealing with that on a single [MULTI](https://redis.io/topics/transactions) call, we push all elements to a tmp list, and that gets renamed it right after, using [RENAME](https://redis.io/commands/rename) overwriting the previous list.

Also, this is only called on new experiments, and whenever an experiment configuration has changed.

Before:
- N RPUSH calls would be made.
- N LSET calls would be made, depending on the scenario.
- 1 extra LTRIM 

Now:
- Single RPUSH with all the alternatives O(n) where n is the number of elements
- 1 RENAME O(1). 

Also removing one extra SISMEMBER check when calling RedisInterface#add_to_set.