### PR TITLE
Remove Sinatra Dependency for Split Dashboard

### DIFF
--- a/lib/split/dashboard.rb
+++ b/lib/split/dashboard.rb
@@ -1,81 +1,40 @@
 # frozen_string_literal: true
 
 require 'split'
-require 'bigdecimal'
-require 'split/dashboard/routing'
-require 'split/dashboard/rendering'
-require 'split/dashboard/action'
+require 'split/dashboard/web'
 
 module Split
   class Dashboard
-    include Routing
-    include Rendering
-
-    get '/' do
-      # Display experiments without a winner at the top of the dashboard
-      @experiments = Split::ExperimentCatalog.all_active_first
-
-      @metrics = Split::Metric.all
-
-      # Display Rails Environment mode (or Rack version if not using Rails)
-      if Object.const_defined?('Rails')
-        @current_env = Rails.env.titlecase
-      else
-        @current_env = "Rack: #{Rack.version}"
+    class << self
+      def middlewares
+        @middlewares ||= []
       end
-      render_erb :index
-    end
 
-    post '/force_alternative' do
-      experiment = Split::ExperimentCatalog.find(params['experiment'])
-      alternative = Split::Alternative.new(params['alternative'], experiment.name)
-
-      cookies = JSON.parse(request.cookies['split_override']) rescue {}
-      cookies[experiment.name] = alternative.name
-      response.set_cookie('split_override', { value: cookies.to_json, path: '/' })
-      redirect url('/')
-    end
-
-    post '/experiment' do
-      @experiment = Split::ExperimentCatalog.find(params['experiment'])
-      @alternative = Split::Alternative.new(params['alternative'], params['experiment'])
-      @experiment.winner = @alternative.name
-      redirect url('/')
-    end
-
-    post '/start' do
-      @experiment = Split::ExperimentCatalog.find(params['experiment'])
-      @experiment.start
-      redirect url('/')
-    end
-
-    post '/reset' do
-      @experiment = Split::ExperimentCatalog.find(params['experiment'])
-      @experiment.reset
-      redirect url('/')
-    end
-
-    post '/reopen' do
-      @experiment = Split::ExperimentCatalog.find(params['experiment'])
-      @experiment.reset_winner
-      redirect url('/')
-    end
-
-    post '/update_cohorting' do
-      @experiment = Split::ExperimentCatalog.find(params['experiment'])
-      case params['cohorting_action'].downcase
-      when "enable"
-        @experiment.enable_cohorting
-      when "disable"
-        @experiment.disable_cohorting
+      def use(*middleware_args, &block)
+        middlewares << [middleware_args, block]
       end
-      redirect url('/')
     end
 
-    delete '/experiment' do
-      @experiment = Split::ExperimentCatalog.find(params['experiment'])
-      @experiment.delete
-      redirect url('/')
+    def self.call(env)
+      @dashboard ||= new
+      @dashboard.call(env)
+    end
+
+    def call(env)
+      app.call(env)
+    end
+
+    def app
+      @app ||= begin
+        middlewares = self.class.middlewares
+
+        Rack::Builder.new do
+          use Rack::MethodOverride
+          run Split::Dashboard::Web
+
+          middlewares.each { |middleware, block| use(*middleware, &block) }
+        end
+      end
     end
   end
 end

--- a/lib/split/dashboard/action.rb
+++ b/lib/split/dashboard/action.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Split
+  class Dashboard
+    class Action
+      include Rendering
+      include Split::Helper
+
+      def initialize(env, block)
+        @action = block
+        @env = env
+      end
+
+      def call
+        instance_eval(&@action)
+      end
+
+      def request
+        @request ||= Rack::Request.new(@env)
+      end
+
+      def response
+        @response ||= Rack::Response.new
+      end
+
+      def params
+        request.params
+      end
+    end
+  end
+end

--- a/lib/split/dashboard/helpers.rb
+++ b/lib/split/dashboard/helpers.rb
@@ -11,7 +11,7 @@ module Split
     end
 
     def path_prefix
-      request.env['SCRIPT_NAME']
+      request.script_name
     end
 
     def number_to_percentage(number, precision = 2)

--- a/lib/split/dashboard/pagination_helpers.rb
+++ b/lib/split/dashboard/pagination_helpers.rb
@@ -6,11 +6,11 @@ module Split
   module DashboardPaginationHelpers
     def pagination_per
       default_per_page = Split.configuration.dashboard_pagination_default_per_page
-      @pagination_per ||= (params[:per] || default_per_page).to_i
+      @pagination_per ||= (params['per'] || default_per_page).to_i
     end
 
     def page_number
-      @page_number ||= (params[:page] || 1).to_i
+      @page_number ||= (params['page'] || 1).to_i
     end
 
     def paginated(collection)

--- a/lib/split/dashboard/rendering.rb
+++ b/lib/split/dashboard/rendering.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'split/dashboard/helpers'
+require 'split/dashboard/pagination_helpers'
+
+module Split
+  class Dashboard
+    module Rendering
+      VIEWS_PATH = File.join(
+        File.dirname(File.expand_path(__FILE__)),
+        'views'
+      )
+
+      def render_erb(view)
+        [200, {}, [erb(view)]]
+      end
+
+      def erb(view, opts = {})
+        render_layout do
+          partial(view, opts)
+        end
+      end
+
+      def partial(view, opts = {})
+        filename = view.to_s + '.erb'
+        file_path = File.join(VIEWS_PATH, filename)
+        raw = File.read(file_path)
+        b = binding
+        (opts[:locals] || {}).each do |k, v|
+          b.local_variable_set(k, v)
+        end
+        ERB.new(raw).result(b)
+      end
+
+      def render_layout(&block)
+        partial(:layout, &block)
+      end
+
+      def redirect(url)
+        response.redirect(url)
+        response.finish
+      end
+
+      include Split::DashboardHelpers
+      include Split::DashboardPaginationHelpers
+    end
+  end
+end

--- a/lib/split/dashboard/routing.rb
+++ b/lib/split/dashboard/routing.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Split
+  class Dashboard
+    module Routing
+      STATIC_RACK = Rack::File.new(
+        File.join(
+          File.dirname(File.expand_path(__FILE__)),
+          'public'
+        )
+      )
+
+      def self.included(mod)
+        mod.extend(ClassMethods)
+      end
+
+      def call(env)
+        self.class.call(env)
+      end
+
+      module ClassMethods
+        def call(env)
+          route = route_for(env["REQUEST_METHOD"], env["PATH_INFO"])
+
+          if route
+            Action.new(env, route).call
+          else
+            STATIC_RACK.call(env)
+          end
+        end
+
+        def get(path, &block)
+          key = ['GET', path]
+          routes[key] = block
+        end
+
+        def post(path, &block)
+          key = ['POST', path]
+          routes[key] = block
+        end
+
+        def delete(path, &block)
+          key = ['DELETE', path]
+          routes[key] = block
+        end
+
+        def routes
+          @routes ||= Hash.new
+        end
+
+        def route_for(method, path)
+          key = [method, path]
+          routes[key]
+        end
+      end
+    end
+  end
+end

--- a/lib/split/dashboard/routing.rb
+++ b/lib/split/dashboard/routing.rb
@@ -14,10 +14,6 @@ module Split
         mod.extend(ClassMethods)
       end
 
-      def call(env)
-        self.class.call(env)
-      end
-
       module ClassMethods
         def call(env)
           route = route_for(env["REQUEST_METHOD"], env["PATH_INFO"])
@@ -49,6 +45,7 @@ module Split
         end
 
         def route_for(method, path)
+          path = '/' if path.empty?
           key = [method, path]
           routes[key]
         end

--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -40,7 +40,7 @@
     <% if goal.nil? %>
       <div class='inline-controls'>
         <small><%= experiment.start_time ? experiment.start_time.strftime('%Y-%m-%d') : 'Unknown' %></small>
-        <%= erb :_controls, :locals => {:experiment => experiment} %>
+        <%= partial :_controls, :locals => {:experiment => experiment} %>
       </div>
     <% end %>
   </div>

--- a/lib/split/dashboard/views/_experiment_with_goal_header.erb
+++ b/lib/split/dashboard/views/_experiment_with_goal_header.erb
@@ -2,7 +2,7 @@
   <div class="experiment-header">
       <div class='inline-controls'>
         <small><%= experiment.start_time ? experiment.start_time.strftime('%Y-%m-%d') : 'Unknown' %></small>
-        <%= erb :_controls, :locals => {:experiment => experiment} %>
+        <%= partial :_controls, locals: {:experiment => experiment} %>
       </div>
   </div>
 </div>

--- a/lib/split/dashboard/views/index.erb
+++ b/lib/split/dashboard/views/index.erb
@@ -8,11 +8,11 @@
 
   <% paginated(@experiments).each do |experiment| %>
     <% if experiment.goals.empty? %>
-      <%= erb :_experiment, :locals => {:goal => nil, :experiment => experiment} %>
+      <%= partial :_experiment, locals: {:goal => nil, :experiment => experiment} %>
     <% else %>
-      <%= erb :_experiment_with_goal_header, :locals => {:experiment => experiment} %>
+      <%= partial :_experiment_with_goal_header, locals: {:experiment => experiment} %>
       <% experiment.goals.each do |g| %>
-        <%= erb :_experiment, :locals => {:goal => g, :experiment => experiment} %>
+        <%= partial :_experiment, locals: {:goal => g, :experiment => experiment} %>
       <% end %>
     <% end %>
   <% end %>

--- a/lib/split/dashboard/web.rb
+++ b/lib/split/dashboard/web.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'split'
+require 'bigdecimal'
+require 'split/dashboard/routing'
+require 'split/dashboard/rendering'
+require 'split/dashboard/action'
+
+module Split
+  class Dashboard
+    class Web
+      include Routing
+      include Rendering
+
+      get '/' do
+        # Display experiments without a winner at the top of the dashboard
+        @experiments = Split::ExperimentCatalog.all_active_first
+
+        @metrics = Split::Metric.all
+
+        # Display Rails Environment mode (or Rack version if not using Rails)
+        if Object.const_defined?('Rails')
+          @current_env = Rails.env.titlecase
+        else
+          @current_env = "Rack: #{Rack.version}"
+        end
+        render_erb :index
+      end
+
+      post '/force_alternative' do
+        experiment = Split::ExperimentCatalog.find(params['experiment'])
+        alternative = Split::Alternative.new(params['alternative'], experiment.name)
+
+        cookies = JSON.parse(request.cookies['split_override']) rescue {}
+        cookies[experiment.name] = alternative.name
+        response.set_cookie('split_override', { value: cookies.to_json, path: '/' })
+        redirect url('/')
+      end
+
+      post '/experiment' do
+        @experiment = Split::ExperimentCatalog.find(params['experiment'])
+        @alternative = Split::Alternative.new(params['alternative'], params['experiment'])
+        @experiment.winner = @alternative.name
+        redirect url('/')
+      end
+
+      post '/start' do
+        @experiment = Split::ExperimentCatalog.find(params['experiment'])
+        @experiment.start
+        redirect url('/')
+      end
+
+      post '/reset' do
+        @experiment = Split::ExperimentCatalog.find(params['experiment'])
+        @experiment.reset
+        redirect url('/')
+      end
+
+      post '/reopen' do
+        @experiment = Split::ExperimentCatalog.find(params['experiment'])
+        @experiment.reset_winner
+        redirect url('/')
+      end
+
+      post '/update_cohorting' do
+        @experiment = Split::ExperimentCatalog.find(params['experiment'])
+        case params['cohorting_action'].downcase
+        when "enable"
+          @experiment.enable_cohorting
+        when "disable"
+          @experiment.disable_cohorting
+        end
+        redirect url('/')
+      end
+
+      delete '/experiment' do
+        @experiment = Split::ExperimentCatalog.find(params['experiment'])
+        @experiment.delete
+        redirect url('/')
+      end
+    end
+  end
+end

--- a/spec/dashboard/pagination_helpers_spec.rb
+++ b/spec/dashboard/pagination_helpers_spec.rb
@@ -8,7 +8,7 @@ describe Split::DashboardPaginationHelpers do
 
   describe '#pagination_per' do
     context 'when params empty' do
-      let(:params) { Hash[] }
+      let(:params) { { } }
 
       it 'returns the default (10)' do
         default_per_page = Split.configuration.dashboard_pagination_default_per_page
@@ -18,7 +18,7 @@ describe Split::DashboardPaginationHelpers do
     end
 
     context 'when params[:per] is 5' do
-      let(:params) { Hash[per: 5] }
+      let(:params) { { 'per' => '5' } }
 
       it 'returns 5' do
         expect(pagination_per).to eql 5
@@ -28,7 +28,7 @@ describe Split::DashboardPaginationHelpers do
 
   describe '#page_number' do
     context 'when params empty' do
-      let(:params) { Hash[] }
+      let(:params) { { } }
 
       it 'returns 1' do
         expect(page_number).to eql 1
@@ -36,7 +36,7 @@ describe Split::DashboardPaginationHelpers do
     end
 
     context 'when params[:page] is "2"' do
-      let(:params) { Hash[page: '2'] }
+      let(:params) { { 'page' => '2' } }
 
       it 'returns 2' do
         expect(page_number).to eql 2
@@ -46,7 +46,7 @@ describe Split::DashboardPaginationHelpers do
 
   describe '#paginated' do
     let(:collection) { (1..20).to_a }
-    let(:params) { Hash[per: '5', page: '3'] }
+    let(:params) { { 'per' => '5', 'page' => '3' } }
 
     it { expect(paginated(collection)).to eql [11, 12, 13, 14, 15] }
   end
@@ -57,7 +57,7 @@ describe Split::DashboardPaginationHelpers do
     end
 
     context 'when page is 3' do
-      let(:params) { Hash[page: '3'] }
+      let(:params) { { 'page' => '3' } }
       it { expect(show_first_page_tag?).to be true }
     end
   end
@@ -72,7 +72,7 @@ describe Split::DashboardPaginationHelpers do
     end
 
     context 'when page is 4' do
-      let(:params) { Hash[page: '4'] }
+      let(:params) { { 'page' => '4' } }
       it { expect(show_first_ellipsis_tag?).to be true }
     end
   end
@@ -87,14 +87,14 @@ describe Split::DashboardPaginationHelpers do
     end
 
     context 'when page is 2' do
-      let(:params) { Hash[page: '2'] }
+      let(:params) { { 'page' => '2' } }
       it { expect(show_prev_page_tag?).to be true }
     end
   end
 
   describe '#prev_page_tag' do
     context 'when page is 2' do
-      let(:params) { Hash[page: '2'] }
+      let(:params) { { 'page' => '2' } }
 
       it do
         expect(prev_page_tag).to eql '<a href="/split?page=1&per=10">1</a>'
@@ -102,7 +102,7 @@ describe Split::DashboardPaginationHelpers do
     end
 
     context 'when page is 3' do
-      let(:params) { Hash[page: '3'] }
+      let(:params) { { 'page' => '3' } }
 
       it do
         expect(prev_page_tag).to eql '<a href="/split?page=2&per=10">2</a>'
@@ -116,26 +116,26 @@ describe Split::DashboardPaginationHelpers do
     end
 
     context 'when page is 2' do
-      let(:params) { Hash[page: '2'] }
+      let(:params) { { 'page' => '2' } }
       it { expect(show_prev_page_tag?).to be true }
     end
   end
 
   describe '#current_page_tag' do
     context 'when page is 1' do
-      let(:params) { Hash[page: '1'] }
+      let(:params) { { 'page' => '1' } }
       it { expect(current_page_tag).to eql '<span><b>1</b></span>' }
     end
 
     context 'when page is 2' do
-      let(:params) { Hash[page: '2'] }
+      let(:params) { { 'page' => '2' } }
       it { expect(current_page_tag).to eql '<span><b>2</b></span>' }
     end
   end
 
   describe '#show_next_page_tag?' do
     context 'when page is 2' do
-      let(:params) { Hash[page: '2'] }
+      let(:params) { { 'page' => '2' } }
 
       context 'when collection length is 20' do
         let(:collection) { (1..20).to_a }
@@ -151,12 +151,12 @@ describe Split::DashboardPaginationHelpers do
 
   describe '#next_page_tag' do
     context 'when page is 1' do
-      let(:params) { Hash[page: '1'] }
+      let(:params) { { 'page' => '1' } }
       it { expect(next_page_tag).to eql '<a href="/split?page=2&per=10">2</a>' }
     end
 
     context 'when page is 2' do
-      let(:params) { Hash[page: '2'] }
+      let(:params) { { 'page' => '2' } }
       it { expect(next_page_tag).to eql '<a href="/split?page=3&per=10">3</a>' }
     end
   end
@@ -175,7 +175,7 @@ describe Split::DashboardPaginationHelpers do
 
   describe '#show_last_ellipsis_tag?' do
     let(:collection) { (1..30).to_a }
-    let(:params) { Hash[per: '5', page: '2'] }
+    let(:params) { { 'per' => '5', 'page' => '2' } }
     it { expect(show_last_ellipsis_tag?(collection)).to be true }
   end
 
@@ -183,12 +183,12 @@ describe Split::DashboardPaginationHelpers do
     let(:collection) { (1..30).to_a }
 
     context 'when page is 5/6' do
-      let(:params) { Hash[per: '5', page: '5'] }
+      let(:params) { { 'per' => '5', 'page' => '5' } }
       it { expect(show_last_page_tag?(collection)).to be false }
     end
 
     context 'when page is 4/6' do
-      let(:params) { Hash[per: '5', page: '4'] }
+      let(:params) { { 'per' => '5', 'page' => '4' } }
       it { expect(show_last_page_tag?(collection)).to be true }
     end
   end

--- a/spec/dashboard_helpers_spec.rb
+++ b/spec/dashboard_helpers_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'split/dashboard/helpers'
 

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -7,14 +7,14 @@ require 'split/dashboard'
 describe Split::Dashboard do
   include Rack::Test::Methods
 
-  class Split::Dashboard
+  class Split::Dashboard::Web
     get '/my_experiment' do
       [200, {}, [ ab_test(params['experiment'], 'blue', 'red') ]]
     end
   end
 
   def app
-    @app ||= Split::Dashboard
+    @app ||= Split::Dashboard.new
   end
 
   def link(color)

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'rack/test'
 require 'split/dashboard'
@@ -6,16 +7,14 @@ require 'split/dashboard'
 describe Split::Dashboard do
   include Rack::Test::Methods
 
-  class TestDashboard < Split::Dashboard
-    include Split::Helper
-
+  class Split::Dashboard
     get '/my_experiment' do
-      ab_test(params[:experiment], 'blue', 'red')
+      [200, {}, [ ab_test(params['experiment'], 'blue', 'red') ]]
     end
   end
 
   def app
-    @app ||= TestDashboard
+    @app ||= Split::Dashboard
   end
 
   def link(color)
@@ -27,7 +26,7 @@ describe Split::Dashboard do
   }
 
   let(:experiment_with_goals) {
-    Split::ExperimentCatalog.find_or_create({"link_color" => ["goal_1", "goal_2"]}, "blue", "red")
+    Split::ExperimentCatalog.find_or_create({ "link_color" => ["goal_1", "goal_2"] }, "blue", "red")
   }
 
   let(:metric) {
@@ -188,7 +187,7 @@ describe Split::Dashboard do
 
     it "calls disable of cohorting when action is disable" do
       post "/update_cohorting?experiment=#{experiment.name}", { "cohorting_action": "disable" }
-      
+
       expect(experiment.cohorting_disabled?).to eq true
     end
 
@@ -226,7 +225,7 @@ describe Split::Dashboard do
 
   it "should mark an alternative as the winner" do
     expect(experiment.winner).to be_nil
-    post "/experiment?experiment=#{experiment.name}", :alternative => 'red'
+    post "/experiment?experiment=#{experiment.name}", alternative: 'red'
 
     expect(last_response).to be_redirect
     expect(experiment.winner.name).to eq('red')

--- a/split.gemspec
+++ b/split.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'redis',           '>= 4.2'
-  s.add_dependency 'sinatra',         '>= 1.2.6'
   s.add_dependency 'rubystats',       '>= 0.3.0'
 
   s.add_development_dependency 'bundler',     '>= 1.17'


### PR DESCRIPTION
Rework on top of #561 it works now 🚀 

Sinatra is only being used for the dashboard. With this PR, we remove this dependency entirely. As we're adding sinatra for several rails apps that are not using sinatra, this is a good thing 🙌 
