### PR TITLE
Remove 'set' parsing for alternatives. Sets were used as storage and deprecated on 0.x

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -431,15 +431,7 @@ module Split
     end
 
     def load_alternatives_from_redis
-      alternatives = case redis.type(@name)
-                     when 'set' # convert legacy sets to lists
-                       alts = redis.smembers(@name)
-                       redis.del(@name)
-                       alts.reverse.each {|a| redis.lpush(@name, a) }
-                       redis.lrange(@name, 0, -1)
-                     else
-                       redis.lrange(@name, 0, -1)
-                     end
+      alternatives = redis.lrange(@name, 0, -1)
       alternatives.map do |alt|
         alt = begin
                 JSON.parse(alt)


### PR DESCRIPTION
Also removes one extra Redis call to 'TYPE' on every experiment.