### PR TITLE
Single HSET to update values, instead of multiple ones. 

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -80,8 +80,8 @@ module Split
         persist_experiment_configuration
       end
 
-      redis.hset(experiment_config_key, :resettable, resettable)
-      redis.hset(experiment_config_key, :algorithm, algorithm.to_s)
+      redis.hset(experiment_config_key, :resettable, resettable,
+                                        :algorithm, algorithm.to_s)
       self
     end
 


### PR DESCRIPTION
One less network roundtrip to Redis during ab_test.