### PR TITLE
add a simple way to load users outside web session

### DIFF
--- a/lib/split/persistence.rb
+++ b/lib/split/persistence.rb
@@ -8,8 +8,10 @@ module Split
     require 'split/persistence/session_adapter'
 
     ADAPTERS = {
-      :cookie => Split::Persistence::CookieAdapter,
-      :session => Split::Persistence::SessionAdapter
+      cookie: Split::Persistence::CookieAdapter,
+      session: Split::Persistence::SessionAdapter,
+      redis: Split::Persistence::RedisAdapter,
+      dual_adapter: Split::Persistence::DualAdapter
     }.freeze
 
     def self.adapter

--- a/lib/split/persistence/redis_adapter.rb
+++ b/lib/split/persistence/redis_adapter.rb
@@ -40,6 +40,10 @@ module Split
         Split.redis.hkeys(redis_key)
       end
 
+      def self.find(user_id)
+        new(nil, user_id)
+      end
+
       def self.with_config(options={})
         self.config.merge!(options)
         self

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -8,7 +8,7 @@ module Split
     def_delegators :@user, :keys, :[], :[]=, :delete
     attr_reader :user
 
-    def initialize(context, adapter=nil)
+    def initialize(context, adapter = nil)
       @user = adapter || Split::Persistence.adapter.new(context)
       @cleaned_up = false
     end
@@ -52,6 +52,16 @@ module Split
         end
       end
       experiment_pairs
+    end
+
+    def self.find(user_id, adapter)
+      adapter = adapter.is_a?(Symbol) ? Split::Persistence::ADAPTERS[adapter] : adapter
+
+      if adapter.respond_to?(:find)
+        User.new(nil, adapter.find(user_id))
+      else
+        nil
+      end
     end
 
     private

--- a/spec/persistence/redis_adapter_spec.rb
+++ b/spec/persistence/redis_adapter_spec.rb
@@ -60,6 +60,15 @@ describe Split::Persistence::RedisAdapter do
     end
   end
 
+  describe '#find' do
+    before { Split::Persistence::RedisAdapter.with_config(:lookup_by => proc{'frag'}, :namespace => 'a_namespace') }
+
+    it "should create and user from a given key" do
+      adapter = Split::Persistence::RedisAdapter.find(2)
+      expect(adapter.redis_key).to eq("a_namespace:2")
+    end
+  end
+
   context 'functional tests' do
     before { Split::Persistence::RedisAdapter.with_config(:lookup_by => 'lookup') }
 

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -72,6 +72,23 @@ describe Split::User do
     end
   end
 
+  context 'allows user to be loaded from adapter' do
+    it 'loads user from adapter (RedisAdapter)' do
+      user = Split::Persistence::RedisAdapter.new(nil, 112233)
+      user['foo'] = 'bar'
+
+      ab_user = Split::User.find(112233, :redis)
+
+      expect(ab_user['foo']).to eql('bar')
+    end
+
+    it 'returns nil if adapter does not implement a finder method' do
+      ab_user = Split::User.find(112233, :dual_adapter)
+      expect(ab_user).to be_nil
+    end
+
+  end
+
   context "instantiated with custom adapter" do
     let(:custom_adapter) { double(:persistence_adapter) }
 


### PR DESCRIPTION
On situations where one might need to recover the ab_test a user is on, this will be helpful. It's possible to do this with the current API, but It requires passing a few 'nil' contexts around. 

```
Split::User.find(11, :redis).active_experiments
=> {"link_text_2"=>"Click Here"}
```

Not fully decided on the API, so this can change. Also, note that this won't work with cookie_adapters etc. 

Closes #489