### PR TITLE
Caching based optimization in the experiment#save path

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,8 +759,7 @@ Split.redis = split_config[Rails.env]
 ### Redis Caching
 
 In some high-volume usage scenarios, Redis load can be incurred by repeated 
-fetches for fairly static data.  Enabling caching will reduce this load, but 
-require a restart for changes to experiment definitions to take effect.
+fetches for fairly static data.  Enabling caching will reduce this load.
 
  ```ruby
 Split.configuration.cache = true

--- a/lib/split/cache.rb
+++ b/lib/split/cache.rb
@@ -18,5 +18,11 @@ module Split
 
       @cache[namespace][key] = yield
     end
+
+    def self.clear_key(key)
+      @cache&.keys&.each do |namespace|
+        @cache[namespace]&.delete(key)
+      end
+    end
   end
 end

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -16,6 +16,13 @@ module Split
       :resettable => true
     }
 
+    def self.find(name)
+      Split.cache(:experiments, name) do
+        return unless Split.redis.exists?(name)
+        Experiment.new(name).tap { |exp| exp.load_from_redis }
+      end
+    end
+
     def initialize(name, options = {})
       options = DEFAULT_OPTIONS.merge(options)
 
@@ -160,6 +167,7 @@ module Split
     def reset_winner
       redis.hdel(:experiment_winner, name)
       @has_winner = false
+      Split::Cache.clear_key(@name)
     end
 
     def start
@@ -226,6 +234,7 @@ module Split
 
     def reset
       Split.configuration.on_before_experiment_reset.call(self)
+      Split::Cache.clear_key(@name)
       alternatives.each(&:reset)
       reset_winner
       Split.configuration.on_experiment_reset.call(self)
@@ -476,12 +485,11 @@ module Split
     end
 
     def experiment_configuration_has_changed?
-      existing_alternatives = load_alternatives_from_redis
-      existing_goals = Split::GoalsCollection.new(@name).load_from_redis
-      existing_metadata = load_metadata_from_redis
-      existing_alternatives.map(&:to_s) != @alternatives.map(&:to_s) ||
-        existing_goals != @goals ||
-        existing_metadata != @metadata
+      existing_experiment = Experiment.find(@name)
+
+      existing_experiment.alternatives.map(&:to_s) != @alternatives.map(&:to_s) ||
+        existing_experiment.goals != @goals ||
+        existing_experiment.metadata != @metadata
     end
 
     def goals_collection

--- a/lib/split/experiment_catalog.rb
+++ b/lib/split/experiment_catalog.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 module Split
   class ExperimentCatalog
     # Return all experiments
@@ -14,10 +13,7 @@ module Split
     end
 
     def self.find(name)
-      Split.cache(:experiment_catalog, name) do
-        return unless Split.redis.exists?(name)
-        Experiment.new(name).tap { |exp| exp.load_from_redis }
-      end
+      Experiment.find(name)
     end
 
     def self.find_or_initialize(metric_descriptor, control = nil, *alternatives)
@@ -49,5 +45,6 @@ module Split
       return experiment_name, goals
     end
     private_class_method :normalize_experiment
+
   end
 end

--- a/lib/split/experiment_catalog.rb
+++ b/lib/split/experiment_catalog.rb
@@ -45,6 +45,5 @@ module Split
       return experiment_name, goals
     end
     private_class_method :normalize_experiment
-
   end
 end

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -21,6 +21,20 @@ describe Split::Cache do
     end
   end
 
+  describe 'clear_key' do
+    before { Split.configuration.cache = true }
+
+    it 'clears the cache' do
+      expect(Time).to receive(:now).and_return(now).exactly(3).times
+      Split::Cache.fetch(namespace, :key1) { Time.now }
+      Split::Cache.fetch(namespace, :key2) { Time.now }
+      Split::Cache.clear_key(:key1)
+
+      Split::Cache.fetch(namespace, :key1) { Time.now }
+      Split::Cache.fetch(namespace, :key2) { Time.now }
+    end
+  end
+
   describe 'fetch' do
 
     subject { Split::Cache.fetch(namespace, key) { Time.now } }


### PR DESCRIPTION
1. Adds caching in the experiment save path to use the cached experiment config instead of making redis calls to compare new and existing configs.

2. Have cache clear in the `Experiment#reset` call which allows runtime update of experiment config without reboot required.

3. Have cache clear in the `Experiment#reset_winner` call which allows runtime update of experiment winner without reboot required.