### PR TITLE
Uset Redis#hmset to keep compatibility with Redis < 4.0

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -87,8 +87,8 @@ module Split
         persist_experiment_configuration
       end
 
-      redis.hset(experiment_config_key, :resettable, resettable,
-                                        :algorithm, algorithm.to_s)
+      redis.hmset(experiment_config_key, :resettable, resettable,
+                                         :algorithm, algorithm.to_s)
       self
     end
 


### PR DESCRIPTION
HMSET is deprecated in favor of HSET on Redis  4.0 (not redis-rb). https://redis.io/commands/hmset But, we still need to keep compatibility for now.
