### PR TITLE
Fix cleanup_old_versions! misbehaviour

### DIFF
--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -38,7 +38,7 @@ module Split
     end
 
     def cleanup_old_versions!(experiment)
-      keys = user.keys.select { |k| k.match(Regexp.new(experiment.name)) }
+      keys = user.keys.select { |k| k.start_with?(experiment.name + ':') }
       keys_without_experiment(keys, experiment.key).each { |key| user.delete(key) }
     end
 

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -38,7 +38,7 @@ module Split
     end
 
     def cleanup_old_versions!(experiment)
-      keys = user.keys.select { |k| k.start_with?(experiment.name + ':') }
+      keys = user.keys.select { |k| k == experiment.name || k.start_with?(experiment.name + ':') }
       keys_without_experiment(keys, experiment.key).each { |key| user.delete(key) }
     end
 

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -17,11 +17,25 @@ describe Split::User do
   end
 
   context '#cleanup_old_versions!' do
-    let(:user_keys) { { 'link_color:1' => 'blue' } }
+    let(:experiment_version) { "#{experiment.name}:1" }
+    let(:second_experiment_version) { "#{experiment.name}_another:1" }
+    let(:third_experiment_version) { "variation_of_#{experiment.name}:1" }
+    let(:user_keys) do
+      {
+        experiment_version => 'blue',
+        second_experiment_version => 'red',
+        third_experiment_version => 'yellow'
+      }
+    end
+
+    before(:each) { @subject.cleanup_old_versions!(experiment) }
 
     it 'removes key if old experiment is found' do
-      @subject.cleanup_old_versions!(experiment)
-      expect(@subject.keys).to be_empty
+      expect(@subject.keys).not_to include(experiment_version)
+    end
+
+    it 'does not remove other keys' do
+      expect(@subject.keys).to include(second_experiment_version, third_experiment_version)
     end
   end 
 


### PR DESCRIPTION
### The problem

I've found that `Split::User#cleanup_old_versions!` method misbehaves when you have multiple running experiments with some common strings in their names.
For example if you have running both `some_test` and `some_test_variation` (or even `variation_of_some_test`), then calling `cleanup_old_versions!` for the first experiment will also drop data for the latter one.

The outcome of this behaviour looks very confusing.
In my case I see participant numbers increase on each page refresh for the second and further tests running in the user session, despite the counter must be unique

### The solution

Don't use regular expression to match experiment names. 
Experiment version keys should be compared from their start and until the colon symbol (`some_test:42` is the example of what is actually stored within persistence adapter)