### PR TITLE
Adds config option for cookie domain

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -11,6 +11,7 @@ module Split
     attr_accessor :enabled
     attr_accessor :persistence
     attr_accessor :persistence_cookie_length
+    attr_accessor :persistence_cookie_domain
     attr_accessor :algorithm
     attr_accessor :store_override
     attr_accessor :start_manually
@@ -226,6 +227,7 @@ module Split
       @experiments = {}
       @persistence = Split::Persistence::SessionAdapter
       @persistence_cookie_length = 31536000 # One year from now
+      @persistence_cookie_domain = nil
       @algorithm = Split::Algorithms::WeightedSample
       @include_rails_helper = true
       @beta_probability_simulations = 10000

--- a/lib/split/persistence/cookie_adapter.rb
+++ b/lib/split/persistence/cookie_adapter.rb
@@ -45,7 +45,7 @@ module Split
       end
 
       def default_options
-        { expires: @expires, path: '/', domain: cookie_domain_config }
+        { expires: @expires, path: '/', domain: cookie_domain_config }.compact
       end
 
       def set_cookie_via_rack(key, value)

--- a/lib/split/persistence/cookie_adapter.rb
+++ b/lib/split/persistence/cookie_adapter.rb
@@ -45,7 +45,7 @@ module Split
       end
 
       def default_options
-        { expires: @expires, path: '/' }
+        { expires: @expires, path: '/', domain: cookie_domain_config }
       end
 
       def set_cookie_via_rack(key, value)
@@ -85,6 +85,10 @@ module Split
 
       def cookie_length_config
         Split.configuration.persistence_cookie_length
+      end
+
+      def cookie_domain_config
+        Split.configuration.persistence_cookie_domain
       end
 
       def action_dispatch?

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -242,4 +242,15 @@ describe Split::Configuration do
     end
   end
 
+  context "persistence cookie domain" do
+    it "should default to nil" do
+      expect(@config.persistence_cookie_domain).to eq(nil)
+    end
+
+    it "should allow the persistence cookie domain to be configured" do
+      @config.persistence_cookie_domain = '.acme.com'
+      expect(@config.persistence_cookie_domain).to eq('.acme.com')
+    end
+  end
+
 end


### PR DESCRIPTION
Allows option to set the domain property of the cookie, so that the library can work across different subdomains.