### PR TITLE
Update RSpec helper to support block syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,10 @@ module SplitHelper
   #   use_ab_test(signup_form: "single_page", pricing: "show_enterprise_prices")
   #
   def use_ab_test(alternatives_by_experiment)
-    allow_any_instance_of(Split::Helper).to receive(:ab_test) do |_receiver, experiment|
-      alternatives_by_experiment.fetch(experiment) { |key| raise "Unknown experiment '#{key}'" }
+    allow_any_instance_of(Split::Helper).to receive(:ab_test) do |_receiver, experiment, &block|
+      variant = alternatives_by_experiment.fetch(experiment) { |key| raise "Unknown experiment '#{key}'" }
+      block.call(variant) unless block.nil?
+      variant
     end
   end
 end


### PR DESCRIPTION
Adds support for the helpers block form  `ab_test(:experiment) { |variant| ... }`, based on the example from RSpec's docs[1].

[1]: https://relishapp.com/rspec/rspec-mocks/v/3-2/docs/configuring-responses/block-implementation#yield-to-the-caller's-block