### PR TITLE
Keep railtie defined under the Split gem namespace

### DIFF
--- a/lib/split.rb
+++ b/lib/split.rb
@@ -74,7 +74,7 @@ end
 
 # Check to see if being run in a Rails application.  If so, wait until before_initialize to run configuration so Gems that create ENV variables have the chance to initialize first.
 if defined?(::Rails)
-  class Railtie < Rails::Railtie
+  class Split::Railtie < Rails::Railtie
     config.before_initialize { Split.configure {} }
   end
 else


### PR DESCRIPTION
This `::Railtie` top-level constant looked lost. I think it belongs to you?