### PR TITLE
Add ability to initialize experiments

### DIFF
--- a/lib/split/dashboard.rb
+++ b/lib/split/dashboard.rb
@@ -21,6 +21,7 @@ module Split
     get '/' do
       # Display experiments without a winner at the top of the dashboard
       @experiments = Split::ExperimentCatalog.all_active_first
+      @unintialized_experiments = Split.configuration.experiments.keys - @experiments.map(&:name)
 
       @metrics = Split::Metric.all
 
@@ -31,6 +32,11 @@ module Split
         @current_env = "Rack: #{Rack.version}"
       end
       erb :index
+    end
+
+    post '/initialize_experiment' do
+      Split::ExperimentCatalog.find_or_create(params[:experiment]) unless params[:experiment].nil? || params[:experiment].empty?
+      redirect url('/')
     end
 
     post '/force_alternative' do

--- a/lib/split/dashboard/public/style.css
+++ b/lib/split/dashboard/public/style.css
@@ -258,7 +258,7 @@ body {
   color: #408C48;
 }
 
-a.button, button, input[type="submit"] {
+.experiment a.button, .experiment button, .experiment input[type="submit"] {
   padding: 4px 10px;
   overflow: hidden;
   background: #d8dae0;
@@ -312,10 +312,13 @@ a.button.green:focus, button.green:focus, input[type="submit"].green:focus {
   background:#768E7A;
 }
 
-#filter, #clear-filter {
+.dashboard-controls input, .dashboard-controls select {
   padding: 10px;
 }
 
+.dashboard-controls-bottom {
+  margin-top: 10px;
+}
 
 .pagination {
   text-align: center;

--- a/lib/split/dashboard/views/index.erb
+++ b/lib/split/dashboard/views/index.erb
@@ -1,10 +1,12 @@
 <% if @experiments.any? %>
   <p class="intro">The list below contains all the registered experiments along with the number of test participants, completed and conversion rate currently in the system.</p>
 
-  <input type="text" placeholder="Begin typing to filter" id="filter" />
-  <input type="button" id="toggle-completed" value="Hide completed" />
-  <input type="button" id="toggle-active" value="Hide active" />
-  <input type="button" id="clear-filter" value="Clear filters" />
+  <div class="dashboard-controls">
+    <input type="text" placeholder="Begin typing to filter" id="filter" />
+    <input type="button" id="toggle-completed" value="Hide completed" />
+    <input type="button" id="toggle-active" value="Hide active" />
+    <input type="button" id="clear-filter" value="Clear filters" />
+  </div>
 
   <% paginated(@experiments).each do |experiment| %>
     <% if experiment.goals.empty? %>
@@ -24,3 +26,16 @@
   <p class="intro">No experiments have started yet, you need to define them in your code and introduce them to your users.</p>
   <p class="intro">Check out the <a href='https://github.com/splitrb/split#readme'>Readme</a> for more help getting started.</p>
 <% end %>
+
+<div class="dashboard-controls dashboard-controls-bottom">
+  <form action="<%= url "/initialize_experiment" %>" method='post'>
+    <label>Add unregistered experiment: </label>
+    <select name="experiment" id="experiment-select">
+      <option selected disabled>experiment</option>
+      <% @unintialized_experiments.sort.each do |experiment_name| %>
+          <option value="<%= experiment_name %>"><%= experiment_name %></option>
+      <% end %>
+    </select>
+    <input type="submit" id="register-experiment-btn" value="register experiment"/>
+  </form>
+<div>

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -201,6 +201,37 @@ describe Split::Dashboard do
     end
   end
 
+  describe "initialize experiment" do
+    before do 
+      Split.configuration.experiments = {
+        :my_experiment => {
+          :alternatives => [ "control", "alternative" ],
+        }
+      }
+    end
+
+    it "initializes the experiment when the experiment is given" do
+      expect(Split::ExperimentCatalog.find("my_experiment")).to be nil
+
+      post "/initialize_experiment", { experiment: "my_experiment"}
+
+      experiment = Split::ExperimentCatalog.find("my_experiment")
+      expect(experiment).to be_a(Split::Experiment)
+    end
+
+    it "does not attempt to intialize the experiment when empty experiment is given" do
+      post "/initialize_experiment", { experiment: ""}
+
+      expect(Split::ExperimentCatalog).to_not receive(:find_or_create)
+    end
+
+    it "does not attempt to intialize the experiment when no experiment is given" do
+      post "/initialize_experiment"
+
+      expect(Split::ExperimentCatalog).to_not receive(:find_or_create)
+    end
+  end
+
   it "should reset an experiment" do
     red_link.participant_count = 5
     blue_link.participant_count = 7


### PR DESCRIPTION
### What problem does this solve?
When using the start_manually experiment configuration, an experiment cannot be started unless ab_test is called so that the experiment is initialized ~ added to the dashboard.

### How does this solve it?
- Adds an endpoint to the dashboard to initialize a given experiment.
- Adds a dropdown to the dashboard populated with all the preconfigured experiments that have yet to be initialized.

![Screen Shot 2022-02-10 at 4 12 28 PM](https://user-images.githubusercontent.com/58270715/153518381-919717be-ee8f-4907-bca2-1255238638d4.png)

