### PR TITLE
Encapsulate Split::Algorithms at our own module to avoid explicit calling rubystats everywhere

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "matrix"
 gem "appraisal"
 gem "codeclimate-test-reporter"

--- a/lib/split.rb
+++ b/lib/split.rb
@@ -2,6 +2,7 @@
 
 require 'redis'
 
+require 'split/algorithms'
 require 'split/algorithms/block_randomization'
 require 'split/algorithms/weighted_sample'
 require 'split/algorithms/whiplash'

--- a/lib/split/algorithms.rb
+++ b/lib/split/algorithms.rb
@@ -1,3 +1,12 @@
+begin
+  require "matrix"
+rescue LoadError => error
+  if error.message.match?(/matrix/)
+    $stderr.puts "You don't have matrix installed in your application. Please add it to your Gemfile and run bundle install"
+    raise
+  end
+end
+
 require 'rubystats'
 
 module Split

--- a/lib/split/algorithms.rb
+++ b/lib/split/algorithms.rb
@@ -1,0 +1,11 @@
+require 'rubystats'
+
+module Split
+  module Algorithms
+    class << self
+      def beta_distribution_rng(a, b)
+        Rubystats::BetaDistribution.new(a, b).rng
+      end
+    end
+  end
+end

--- a/lib/split/algorithms/whiplash.rb
+++ b/lib/split/algorithms/whiplash.rb
@@ -2,7 +2,6 @@
 
 # A multi-armed bandit implementation inspired by
 # @aaronsw and victorykit/whiplash
-require 'rubystats'
 
 module Split
   module Algorithms
@@ -17,7 +16,7 @@ module Split
         def arm_guess(participants, completions)
           a = [participants, 0].max
           b = [participants-completions, 0].max
-          Rubystats::BetaDistribution.new(a+fairness_constant, b+fairness_constant).rng
+          Split::Algorithms.beta_distribution_rng(a + fairness_constant, b + fairness_constant)
         end
 
         def best_guess(alternatives)

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rubystats'
-
 module Split
   class Experiment
     attr_accessor :name
@@ -363,7 +361,7 @@ module Split
       beta_params.each do |alternative, params|
         alpha = params[0]
         beta = params[1]
-        simulated_conversion_rate = Rubystats::BetaDistribution.new(alpha, beta).rng
+        simulated_conversion_rate = Split::Algorithms.beta_distribution_rng(alpha, beta)
         simulated_cr_hash[alternative] = simulated_conversion_rate
       end
 


### PR DESCRIPTION
- Encapsulates RubyStats on its own module. Avoiding calling it from other places in code. Split just needs the BetaDistribution.
- Warns if matrix is not installed ([stblib made it into a gem](https://github.com/ruby/matrix)). Although this should be fixed on rubystats upstream, for now, we try to warn users and to make our own specs pass.