### PR TITLE
Handle when Rails is partially loaded as a Gem

### DIFF
--- a/lib/split/dashboard.rb
+++ b/lib/split/dashboard.rb
@@ -26,7 +26,7 @@ module Split
       @metrics = Split::Metric.all
 
       # Display Rails Environment mode (or Rack version if not using Rails)
-      if Object.const_defined?("Rails")
+      if Object.const_defined?("Rails") && Rails.respond_to?(:env)
         @current_env = Rails.env.titlecase
       else
         @current_env = "Rack: #{Rack.version}"


### PR DESCRIPTION
...and not an application

```
NoMethodError: undefined method `env' for Rails:Module
    /bundle/ruby/3.0.0/gems/split-3.4.1/lib/split/dashboard.rb:28:in `block in <class:Dashboard>'
```