### PR TITLE
Add support for redis-client, which does not automatically cast types to strings

### DIFF
--- a/lib/split/alternative.rb
+++ b/lib/split/alternative.rb
@@ -166,7 +166,7 @@ module Split
     end
 
     def reset
-      Split.redis.hmset key, "participant_count", 0, "completed_count", 0, "recorded_info", nil
+      Split.redis.hmset key, "participant_count", 0, "completed_count", 0, "recorded_info", nil.to_s
       unless goals.empty?
         goals.each do |g|
           field = "completed_count:#{g}"

--- a/lib/split/alternative.rb
+++ b/lib/split/alternative.rb
@@ -166,7 +166,7 @@ module Split
     end
 
     def reset
-      Split.redis.hmset key, "participant_count", 0, "completed_count", 0, "recorded_info", nil.to_s
+      Split.redis.hmset key, "participant_count", 0, "completed_count", 0, "recorded_info", ""
       unless goals.empty?
         goals.each do |g|
           field = "completed_count:#{g}"

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -85,7 +85,7 @@ module Split
         persist_experiment_configuration
       end
 
-      redis.hmset(experiment_config_key, :resettable, resettable,
+      redis.hmset(experiment_config_key, :resettable, resettable.to_s,
                                          :algorithm, algorithm.to_s)
       self
     end
@@ -408,12 +408,12 @@ module Split
 
     def disable_cohorting
       @cohorting_disabled = true
-      redis.hset(experiment_config_key, :cohorting, true)
+      redis.hset(experiment_config_key, :cohorting, true.to_s)
     end
 
     def enable_cohorting
       @cohorting_disabled = false
-      redis.hset(experiment_config_key, :cohorting, false)
+      redis.hset(experiment_config_key, :cohorting, false.to_s)
     end
 
     protected

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -68,7 +68,7 @@ describe Split::Experiment do
       experiment_start_time = Time.parse("Sat Mar 03 14:01:03")
       expect(Time).to receive(:now).twice.and_return(experiment_start_time)
       experiment.save
-      Split.redis.hset(:experiment_start_times, experiment.name, experiment_start_time)
+      Split.redis.hset(:experiment_start_times, experiment.name, experiment_start_time.to_s)
 
       expect(Split::ExperimentCatalog.find("basket_text").start_time).to eq(experiment_start_time)
     end


### PR DESCRIPTION
**Problem**
CI fails on `main`. 

Turns out that Redis [started using `redis-client` gem as a transport layer](https://github.com/redis/redis-rb/commit/08a21001b5f27088a412fbe7a6fba8d558eade40#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR12), which raises errors on non-string types.

> <img width="883" alt="image" src="https://user-images.githubusercontent.com/2563994/189643408-d49fcc44-5498-49e0-9e05-9525fb6f16de.png">

**Solution**
Cast redis arguments to strings until tests pass :-)

**Notes**
That should unblock working on actual features/fixes