### PR TITLE
Stop crashing on non-hash json

### DIFF
--- a/lib/split/persistence/cookie_adapter.rb
+++ b/lib/split/persistence/cookie_adapter.rb
@@ -70,7 +70,8 @@ module Split
         def hash
           @hash ||= if cookies = @cookies[:split.to_s]
             begin
-              JSON.parse(cookies)
+              parsed = JSON.parse(cookies)
+              parsed.is_a?(Hash) ? parsed : {}
             rescue JSON::ParserError
               {}
             end

--- a/spec/persistence/cookie_adapter_spec.rb
+++ b/spec/persistence/cookie_adapter_spec.rb
@@ -14,10 +14,8 @@ describe Split::Persistence::CookieAdapter do
       end
 
       it "handles invalid JSON" do
-        context.request.cookies[:split] = {
-          value: '{"foo":2,',
-          expires: Time.now
-        }
+        context.request.cookies["split"] = "{\"foo\":2,"
+
         expect(subject["my_key"]).to be_nil
         subject["my_key"] = "my_value"
         expect(subject["my_key"]).to eq("my_value")

--- a/spec/persistence/cookie_adapter_spec.rb
+++ b/spec/persistence/cookie_adapter_spec.rb
@@ -20,6 +20,22 @@ describe Split::Persistence::CookieAdapter do
         subject["my_key"] = "my_value"
         expect(subject["my_key"]).to eq("my_value")
       end
+
+      it "ignores valid JSON of invalid type (integer)" do
+        context.request.cookies["split"] = "2"
+
+        expect(subject["my_key"]).to be_nil
+        subject["my_key"] = "my_value"
+        expect(subject["my_key"]).to eq("my_value")
+      end
+
+      it "ignores valid JSON of invalid type (array)" do
+        context.request.cookies["split"] = "[\"foo\", \"bar\"]"
+
+        expect(subject["my_key"]).to be_nil
+        subject["my_key"] = "my_value"
+        expect(subject["my_key"]).to eq("my_value")
+      end
     end
 
     describe "#delete" do


### PR DESCRIPTION
**Problem**
When `split` cookie is a valid, json encoded String, a `NoMethodError` is raised. (See https://github.com/splitrb/split/issues/695 )

**Solution**
Add an empty hash fallback for unsupported types

Resolves #695 

**Notes**
- The pre-existing test for invalid JSON seemed broken, so I (hopefully) fixed it