### PR TITLE
Fix deprecation warning with Redis 4.8.0

### DIFF
--- a/lib/split/redis_interface.rb
+++ b/lib/split/redis_interface.rb
@@ -20,6 +20,8 @@ module Split
     end
 
     def add_to_set(set_name, value)
+      return redis.sadd?(set_name, value) if redis.respond_to?(:sadd?)
+
       redis.sadd(set_name, value)
     end
 

--- a/spec/redis_interface_spec.rb
+++ b/spec/redis_interface_spec.rb
@@ -40,5 +40,15 @@ describe Split::RedisInterface do
       add_to_set
       expect(Split.redis.sismember(set_name, "something")).to be true
     end
+
+    context "when a Redis version is used that supports the 'sadd?' method" do
+      before { expect(Split.redis).to receive(:respond_to?).with(:sadd?).and_return(true) }
+
+      it "will use this method instead of 'sadd'" do
+        expect(Split.redis).to receive(:sadd?).with(set_name, "something")
+        expect(Split.redis).not_to receive(:sadd).with(set_name, "something")
+        add_to_set
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes the following deprecation warning when using Redis 4.8.0:

```
Redis#sadd will always return an Integer in Redis 5.0.0.
Use Redis#sadd? instead.
```

As the return value of `redis.sadd` is not used, we can simply replace the `.sadd` call with `.sadd?`.

see
- https://github.com/redis/redis-rb/blob/4.x/CHANGELOG.md#480
- #700 