### PR TITLE
Add matrix as a default dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "rubocop", require: false
-gem "matrix"
 gem "codeclimate-test-reporter"

--- a/gemfiles/7.0.gemfile
+++ b/gemfiles/7.0.gemfile
@@ -3,6 +3,5 @@ source "https://rubygems.org"
 gem "rubocop", require: false
 gem "codeclimate-test-reporter"
 gem "rails", "~> 7.0"
-gem "matrix"
 
 gemspec path: "../"

--- a/lib/split/algorithms.rb
+++ b/lib/split/algorithms.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "matrix"
-rescue LoadError => error
-  if error.message.match?(/matrix/)
-    $stderr.puts "You don't have matrix installed in your application. Please add it to your Gemfile and run bundle install"
-    raise
-  end
-end
-
+require "matrix"
 require "rubystats"
 
 module Split

--- a/split.gemspec
+++ b/split.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency "redis",           ">= 4.2"
   s.add_dependency "sinatra",         ">= 1.2.6"
   s.add_dependency "rubystats",       ">= 0.3.0"
+  s.add_dependency "matrix"
 
   s.add_development_dependency "bundler",     ">= 1.17"
   s.add_development_dependency "simplecov",   "~> 0.15"


### PR DESCRIPTION
Matrix is actually a dependency from rubystats, which we use for beta_distribution.

For now, I think it's ok to ensure matrix is loaded as a split dependency as we always require it. 

Closes #704 