### PR TITLE
Fix case when extra_infos[0] is null

### DIFF
--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -16,7 +16,7 @@
   summary_texts = {}
   extra_columns.each do |column|
     extra_infos = experiment.alternatives.map(&:extra_info).select{|extra_info| extra_info && extra_info[column] }
-    if extra_infos[0][column].kind_of?(Numeric)
+    if extra_infos.dig(0, column) && extra_infos[0][column].kind_of?(Numeric)
       summary_texts[column] = extra_infos.inject(0){|sum, extra_info| sum += extra_info[column]}
     else
       summary_texts[column] = "N/A"


### PR DESCRIPTION
**Problem**

If some records have extra_infos and some do not, then check on line 19 of `_experiment.erb` will fail on trying to access a column of null. 

**Solution**

And an extra check to see if that info exists before checking that its a of type Numeric