### PR TITLE
CROSSSLOT keys issue fix when using redis cluster

### DIFF
--- a/lib/split/redis_interface.rb
+++ b/lib/split/redis_interface.rb
@@ -11,6 +11,7 @@ module Split
       if list_values.length > 0
         redis.multi do |multi|
           tmp_list = "#{list_name}_tmp"
+          tmp_list += redis_namespace_used? ? "{#{Split.redis.namespace}:#{list_name}}" : "{#{list_name}}"
           multi.rpush(tmp_list, list_values)
           multi.rename(tmp_list, list_name)
         end
@@ -27,5 +28,9 @@ module Split
 
     private
       attr_accessor :redis
+
+      def redis_namespace_used?
+        Redis.const_defined?("Namespace") && Split.redis.is_a?(Redis::Namespace)
+      end
   end
 end


### PR DESCRIPTION
Addresses issue https://github.com/splitrb/split/issues/709

- Intentionally did not write test as we will need to set up Redis cluster in `spec/spec_helper.rb` based on the compatible redis gem version.