### PR TITLE
Convert value to string before saving

### DIFF
--- a/lib/split/persistence/redis_adapter.rb
+++ b/lib/split/persistence/redis_adapter.rb
@@ -27,7 +27,7 @@ module Split
       end
 
       def []=(field, value)
-        Split.redis.hset(redis_key, field, value)
+        Split.redis.hset(redis_key, field, value.to_s)
         expire_seconds = self.class.config[:expire_seconds]
         Split.redis.expire(redis_key, expire_seconds) if expire_seconds
       end

--- a/spec/persistence/redis_adapter_spec.rb
+++ b/spec/persistence/redis_adapter_spec.rb
@@ -73,9 +73,9 @@ describe Split::Persistence::RedisAdapter do
     before { Split::Persistence::RedisAdapter.with_config(lookup_by: "lookup") }
 
     describe "#[] and #[]=" do
-      it "should set and return the value for given key" do
-        subject["my_key"] = "my_value"
-        expect(subject["my_key"]).to eq("my_value")
+      it "should convert to string, set and return the value for given key" do
+        subject["my_key"] = true
+        expect(subject["my_key"]).to eq("true")
       end
     end
 


### PR DESCRIPTION
Same problem as in 
https://github.com/splitrb/split/pull/696

Since redis values in hashes might be only strings, it makes sense to convert every value to a string.