### PR TITLE
Support Redis replica instance for reads

### DIFF
--- a/lib/split.rb
+++ b/lib/split.rb
@@ -49,12 +49,27 @@ module Split
     end
   end
 
+  def redis2=(server)
+    @redis2 = if server.is_a?(String)
+      Redis.new(url: server)
+    elsif server.respond_to?(:smembers)
+      server
+    end
+  end
+
   # Returns the current Redis connection. If none has been created, will
   # create a new one.
   def redis
     return @redis if @redis
     self.redis = self.configuration.redis
     self.redis
+  end
+
+  # replica redis connection
+  def redis2
+    return @redis2 if @redis2
+    self.redis2 = self.configuration.redis2
+    self.redis2
   end
 
   # Call this method to modify defaults in your initializers.

--- a/lib/split/alternative.rb
+++ b/lib/split/alternative.rb
@@ -29,7 +29,7 @@ module Split
 
     def p_winner(goal = nil)
       field = set_prob_field(goal)
-      @p_winner = Split.redis.hget(key, field).to_f
+      @p_winner = Split.redis2.hget(key, field).to_f
     end
 
     def set_p_winner(prob, goal = nil)
@@ -38,7 +38,7 @@ module Split
     end
 
     def participant_count
-      Split.redis.hget(key, "participant_count").to_i
+      Split.redis2.hget(key, "participant_count").to_i
     end
 
     def participant_count=(count)
@@ -47,7 +47,7 @@ module Split
 
     def completed_count(goal = nil)
       field = set_field(goal)
-      Split.redis.hget(key, field).to_i
+      Split.redis2.hget(key, field).to_i
     end
 
     def all_completed_count
@@ -127,7 +127,7 @@ module Split
     end
 
     def extra_info
-      data = Split.redis.hget(key, "recorded_info")
+      data = Split.redis2.hget(key, "recorded_info")
       if data && data.length > 1
         begin
           JSON.parse(data)

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -28,6 +28,7 @@ module Split
     attr_accessor :beta_probability_simulations
     attr_accessor :winning_alternative_recalculation_interval
     attr_accessor :redis
+    attr_accessor :redis2
     attr_accessor :dashboard_pagination_default_per_page
     attr_accessor :cache
 
@@ -233,6 +234,7 @@ module Split
       @beta_probability_simulations = 10000
       @winning_alternative_recalculation_interval = 60 * 60 * 24 # 1 day
       @redis = ENV.fetch(ENV.fetch("REDIS_PROVIDER", "REDIS_URL"), "redis://localhost:6379")
+      @redis2 = ENV['REDIS_REPLICA_URL'] || @redis
       @dashboard_pagination_default_per_page = 10
     end
 

--- a/lib/split/experiment_catalog.rb
+++ b/lib/split/experiment_catalog.rb
@@ -5,7 +5,7 @@ module Split
     # Return all experiments
     def self.all
       # Call compact to prevent nil experiments from being returned -- seems to happen during gem upgrades
-      Split.redis.smembers(:experiments).map { |e| find(e) }.compact
+      Split.redis2.smembers(:experiments).map { |e| find(e) }.compact
     end
 
     # Return experiments without a winner (considered "active") first

--- a/lib/split/goals_collection.rb
+++ b/lib/split/goals_collection.rb
@@ -8,7 +8,7 @@ module Split
     end
 
     def load_from_redis
-      Split.redis.lrange(goals_key, 0, -1)
+      Split.redis2.lrange(goals_key, 0, -1)
     end
 
     def load_from_configuration

--- a/lib/split/metric.rb
+++ b/lib/split/metric.rb
@@ -14,7 +14,7 @@ module Split
     end
 
     def self.load_from_redis(name)
-      metric = Split.redis.hget(:metrics, name)
+      metric = Split.redis2.hget(:metrics, name)
       if metric
         experiment_names = metric.split(",")
 
@@ -54,7 +54,7 @@ module Split
     end
 
     def self.all
-      redis_metrics = Split.redis.hgetall(:metrics).collect do |key, value|
+      redis_metrics = Split.redis2.hgetall(:metrics).collect do |key, value|
         find(key)
       end
       configuration_metrics = Split.configuration.metrics.collect do |key, value|

--- a/lib/split/persistence/redis_adapter.rb
+++ b/lib/split/persistence/redis_adapter.rb
@@ -23,7 +23,7 @@ module Split
       end
 
       def [](field)
-        Split.redis.hget(redis_key, field)
+        Split.redis2.hget(redis_key, field)
       end
 
       def []=(field, value)
@@ -37,7 +37,7 @@ module Split
       end
 
       def keys
-        Split.redis.hkeys(redis_key)
+        Split.redis2.hkeys(redis_key)
       end
 
       def self.find(user_id)


### PR DESCRIPTION
Split is quite read intensive on Redis when retrieving experiment/variation information for each end user. This is to move the reads to the replica Redis instance in order to better share the load.