### PR TITLE
Fix context shim override behavior

### DIFF
--- a/lib/split/encapsulated_helper.rb
+++ b/lib/split/encapsulated_helper.rb
@@ -23,6 +23,14 @@ module Split
         @context = context
       end
 
+      def params
+        request.params if request_present?
+      end
+
+      def request
+        @context.request if @context.respond_to?(:request)
+      end
+
       def ab_user
         @ab_user ||= Split::User.new(@context)
       end

--- a/spec/encapsulated_helper_spec.rb
+++ b/spec/encapsulated_helper_spec.rb
@@ -5,19 +5,21 @@ require "spec_helper"
 describe Split::EncapsulatedHelper do
   include Split::EncapsulatedHelper
 
-  def params
-    raise NoMethodError, "This method is not really defined"
-  end
-
   describe "ab_test" do
     before do
       allow_any_instance_of(Split::EncapsulatedHelper::ContextShim).to receive(:ab_user)
       .and_return(mock_user)
     end
 
-    it "should not raise an error when params raises an error" do
-      expect { params }.to raise_error(NoMethodError)
-      expect { ab_test("link_color", "blue", "red") }.not_to raise_error
+    context "when params raises an error" do
+      before do
+        allow(self).to receive(:params).and_raise(NoMethodError)
+      end
+
+      it "should not raise an error " do
+        expect { params }.to raise_error(NoMethodError)
+        expect { ab_test("link_color", "blue", "red") }.not_to raise_error
+      end
     end
 
     it "calls the block with selected alternative" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,11 +44,20 @@ def params
   @params ||= {}
 end
 
-def request(ua = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; de-de) AppleWebKit/533.20.25 (KHTML, like Gecko) Version/5.0.4 Safari/533.20.27")
-  @request ||= begin
-    r = OpenStruct.new
-    r.user_agent = ua
-    r.ip = "192.168.1.1"
-    r
-  end
+def request
+  @request ||= build_request
+end
+
+def build_request(
+  ua: "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; de-de) AppleWebKit/533.20.25 (KHTML, like Gecko) Version/5.0.4 Safari/533.20.27",
+  ip: "192.168.1.1",
+  params: {},
+  cookies: {}
+)
+  r = OpenStruct.new
+  r.user_agent = ua
+  r.ip = "192.168.1.1"
+  r.params = params
+  r.cookies = cookies
+  r
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,7 +56,7 @@ def build_request(
 )
   r = OpenStruct.new
   r.user_agent = ua
-  r.ip = "192.168.1.1"
+  r.ip = ip
   r.params = params
   r.cookies = cookies
   r


### PR DESCRIPTION
I'll try to summarize the problem as much as possible:

The split has this class:

```ruby
class ContextShim
  include Split::Helper
  public :ab_test, :ab_finished

  def initialize(context)
    @context = context
  end

  def ab_user
    @ab_user ||= Split::User.new(@context)
  end
end
```
Which includes:

```ruby
include Split::Helper
```
If we use the context shim this way:

```ruby
def split
  # self is a class that has the methods 'params' and 'request'
  @split ||= ::Split::EncapsulatedHelper::ContextShim.new(self) 
end
```

inside a high level abstraction, we got a problem.

### Problem
The override of ab via URL (`?ab_test[my_test]=variant`) and Split panel (cookies) doesn't work.
It doesn't work because `Split::Helper` uses these methods:

```ruby
def override_alternative_by_params(experiment_name)
  defined?(params) && params[OVERRIDE_PARAM_NAME] && params[OVERRIDE_PARAM_NAME][experiment_name]
end

def override_alternative_by_cookies(experiment_name)
  return unless defined?(request)

  if request.cookies && request.cookies.key?("split_override")
    experiments = JSON.parse(request.cookies["split_override"]) rescue {}
    experiments[experiment_name]
  end
end
```

Which depend on `defined?(params)` and `defined?(request)`, which are in `@context` but not in the scope of `ContextShim`.
In other words:
If we add params and request to the scope of `ContextShim`, we can solve the problem.

### Solution

Include these methods in `ContextShim`:

```ruby
def params
  request.params if request_present?
end

def request
  @context.request if @context.respond_to?(:request)
end
```

I also create a `request_present?` and `params_present?` methods in `Split::Helper` to avoid problems when request or params are defined but returning `nil`: This is the case when `@context` don't implement `request` or `params`