### PR TITLE
Fix context shim override behavior

### DIFF
--- a/lib/split/encapsulated_helper.rb
+++ b/lib/split/encapsulated_helper.rb
@@ -24,7 +24,7 @@ module Split
       end
 
       def params
-        request.params if request_present?
+        request.params if request && request.respond_to?(:params)
       end
 
       def request

--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -163,11 +163,11 @@ module Split
     end
 
     def params_present?
-      defined?(params) && params != nil
+      defined?(params) && params
     end
 
     def request_present?
-      defined?(request) && request != nil
+      defined?(request) && request
     end
 
     def active_experiments


### PR DESCRIPTION
Building this on top of https://github.com/splitrb/split/pull/721 

- Refactored specs a bit, to not depend on spec_helper for everything
- Minor changes when verifying if request/params were present or not