### PR TITLE
Add support for recent Ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,14 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7"]
+        ruby: ["3.5.0-preview1", "3.4", "3.3", "3.2", "3.1", "3.0", "2.7"]
         rails: ["8.0", "7.2", "7.1", "6.1"]
         exclude:
           - rails: "6.1"
             ruby: "3.4"
+
+          - rails: "6.1"
+            ruby: "3.5.0-preview1"
 
           - rails: "7.2"
             ruby: "2.7"

--- a/lib/split/redis_interface.rb
+++ b/lib/split/redis_interface.rb
@@ -30,7 +30,7 @@ module Split
       attr_accessor :redis
 
       def redis_namespace_used?
-        Redis.const_defined?("Namespace") && Split.redis.is_a?(Redis::Namespace)
+        defined?(Redis::Namespace) && Split.redis.is_a?(Redis::Namespace)
       end
   end
 end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -670,7 +670,7 @@ describe Split::Helper do
 
   describe "when user is a robot" do
     before(:each) do
-      @request = OpenStruct.new(user_agent: "Googlebot/2.1 (+http://www.google.com/bot.html)")
+      @request = build_request(user_agent: "Googlebot/2.1 (+http://www.google.com/bot.html)")
     end
 
     describe "ab_test" do
@@ -768,7 +768,7 @@ describe Split::Helper do
   describe "when ip address is ignored" do
     context "individually" do
       before(:each) do
-        @request = OpenStruct.new(ip: "81.19.48.130")
+        @request = build_request(ip: "81.19.48.130")
         Split.configure do |c|
           c.ignore_ip_addresses << "81.19.48.130"
         end
@@ -779,7 +779,7 @@ describe Split::Helper do
 
     context "for a range" do
       before(:each) do
-        @request = OpenStruct.new(ip: "81.19.48.129")
+        @request = build_request(ip: "81.19.48.129")
         Split.configure do |c|
           c.ignore_ip_addresses << /81\.19\.48\.[0-9]+/
         end
@@ -790,7 +790,7 @@ describe Split::Helper do
 
     context "using both a range and a specific value" do
       before(:each) do
-        @request = OpenStruct.new(ip: "81.19.48.128")
+        @request = build_request(ip: "81.19.48.128")
         Split.configure do |c|
           c.ignore_ip_addresses << "81.19.48.130"
           c.ignore_ip_addresses << /81\.19\.48\.[0-9]+/
@@ -802,7 +802,7 @@ describe Split::Helper do
 
     context "when ignored other address" do
       before do
-        @request = OpenStruct.new(ip: "1.1.1.1")
+        @request = build_request(ip: "1.1.1.1")
         Split.configure do |c|
           c.ignore_ip_addresses << "81.19.48.130"
         end
@@ -819,7 +819,7 @@ describe Split::Helper do
 
   describe "when user is previewing" do
     before(:each) do
-      @request = OpenStruct.new(headers: { "x-purpose" => "preview" })
+      @request = build_request(headers: { "x-purpose" => "preview" })
     end
 
     it_behaves_like "a disabled test"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ require "simplecov"
 SimpleCov.start
 
 require "split"
-require "ostruct"
 require "yaml"
 require "pry"
 
@@ -48,16 +47,20 @@ def request
   @request ||= build_request
 end
 
+DummyRequest = Struct.new(:user_agent, :ip, :params, :cookies, :headers)
+
 def build_request(
-  ua: "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; de-de) AppleWebKit/533.20.25 (KHTML, like Gecko) Version/5.0.4 Safari/533.20.27",
+  user_agent: "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; de-de) AppleWebKit/533.20.25 (KHTML, like Gecko) Version/5.0.4 Safari/533.20.27",
   ip: "192.168.1.1",
   params: {},
-  cookies: {}
+  cookies: {},
+  headers: {}
 )
-  r = OpenStruct.new
-  r.user_agent = ua
+  r = DummyRequest.new
+  r.user_agent = user_agent
   r.ip = ip
   r.params = params
   r.cookies = cookies
+  r.headers = headers
   r
 end

--- a/split.gemspec
+++ b/split.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rubystats",       ">= 0.3.0"
   s.add_dependency "matrix"
   s.add_dependency "bigdecimal"
+  s.add_dependency "cgi"
 
   s.add_development_dependency "bundler",     ">= 1.17"
   s.add_development_dependency "simplecov",   "~> 0.15"


### PR DESCRIPTION
- Remove OStruct usage
- Add CGI as a dependency for Ruby 3.5+
- Add Ruby 3.5.0 preview to the matrix