### PR TITLE
chore(ci): add ruby 4.0 to the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,14 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: ["3.5.0-preview1", "3.4", "3.3", "3.2", "3.1", "3.0", "2.7"]
-        rails: ["8.0", "7.2", "7.1", "6.1"]
+        ruby: ["4.0", "3.4", "3.3", "3.2", "3.1", "3.0", "2.7"]
+        rails: ["8.1", "8.0", "7.2", "7.1", "6.1"]
         exclude:
           - rails: "6.1"
             ruby: "3.4"
 
           - rails: "6.1"
-            ruby: "3.5.0-preview1"
+            ruby: "4.0"
 
           - rails: "7.2"
             ruby: "2.7"
@@ -26,6 +26,14 @@ jobs:
             ruby: "3.0"
           - rails: "8.0"
             ruby: "3.1"
+
+          - rails: "8.1"
+            ruby: "2.7"
+          - rails: "8.1"
+            ruby: "3.0"
+          - rails: "8.1"
+            ruby: "3.1"
+
     runs-on: ubuntu-latest
 
     services:

--- a/spec/encapsulated_helper_spec.rb
+++ b/spec/encapsulated_helper_spec.rb
@@ -18,11 +18,15 @@ describe Split::EncapsulatedHelper do
     context "inside a view" do
       it "works inside ERB" do
         require "erb"
-        template = ERB.new(<<-ERB.split(/\s+/s).map(&:strip).join(" "), nil, "%")
-          foo <% context_shim.ab_test(:foo, '1', '2') do |alt, meta| %>
-            static <%= alt %>
-          <% end %>
+
+        html = <<-ERB.split(/\s+/s).map(&:strip).join(" ")
+        foo <% context_shim.ab_test(:foo, '1', '2') do |alt, meta| %>
+          static <%= alt %>
+        <% end %>
         ERB
+
+        template = ERB.new(html, trim_mode: "%")
+
         expect(template.result(binding)).to match(/foo  static \d/)
       end
     end


### PR DESCRIPTION
This adds Ruby 4.0 an Rails 8.1 to the test matrix

Also fixed, ERB.new being used with an old syntax for initialize. This got removed and we had to update it.