### PR TITLE
Refactor Experiment Storage 

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -97,7 +97,7 @@ module Split
     end
 
     def new_record?
-      ExperimentCatalog.find(name).nil?
+      !@redis_storage.exists?
     end
 
     def ==(obj)

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -83,8 +83,12 @@ module Split
         persist_experiment_configuration
       end
 
-      redis.hmset(experiment_config_key, :resettable, resettable.to_s,
-                                         :algorithm, algorithm.to_s)
+      stored_data = @redis_storage.load
+      if stored_data[:resettable] != resettable.to_s ||
+         stored_data[:algorithm] != algorithm.to_s
+        redis.hmset(experiment_config_key, :resettable, resettable.to_s,
+                                           :algorithm, algorithm.to_s)
+      end
       self
     end
 

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -175,7 +175,7 @@ module Split
     end
 
     def start_time
-      Split.cache(:experiment_start_times, @name) do
+      @start_time ||= Split.cache(:experiment_start_times, @name) do
         t = redis.hget(:experiment_start_times, @name)
         if t
           # Check if stored time is an integer

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "split/experiment_storage"
+
 module Split
   class Experiment
     attr_accessor :name
@@ -26,6 +28,9 @@ module Split
 
       @name = name.to_s
 
+      @config_storage = ExperimentStorage::ConfigStorage.new(name)
+      @redis_storage = ExperimentStorage::RedisStorage.new(name)
+
       extract_alternatives_from_options(options)
     end
 
@@ -50,22 +55,15 @@ module Split
 
       if alts.length == 1
         if alts[0].is_a? Hash
-          alts = alts[0].map { |k, v| { k => v } }
-        end
-      end
-
-      if alts.empty?
-        exp_config = Split.configuration.experiment_for(name)
-        if exp_config
-          alts = load_alternatives_from_configuration
-          options[:goals] = Split::GoalsCollection.new(@name).load_from_configuration
-          options[:metadata] = load_metadata_from_configuration
-          options[:resettable] = exp_config[:resettable]
-          options[:algorithm] = exp_config[:algorithm]
+          alts[0].map! { |k, v| { k => v } }
         end
       end
 
       options[:alternatives] = alts
+
+      if alts.empty? && @config_storage.exists?
+        options.merge!(@config_storage.load)
+      end
 
       set_alternatives_and_options(options)
 
@@ -257,17 +255,7 @@ module Split
     end
 
     def load_from_redis
-      exp_config = redis.hgetall(experiment_config_key)
-
-      options = {
-        resettable: exp_config["resettable"],
-        algorithm: exp_config["algorithm"],
-        alternatives: load_alternatives_from_redis,
-        goals: Split::GoalsCollection.new(@name).load_from_redis,
-        metadata: load_metadata_from_redis
-      }
-
-      set_alternatives_and_options(options)
+      set_alternatives_and_options(@redis_storage.load)
     end
 
     def can_calculate_winning_alternatives?
@@ -428,37 +416,6 @@ module Split
     protected
       def experiment_config_key
         "experiment_configurations/#{@name}"
-      end
-
-      def load_metadata_from_configuration
-        Split.configuration.experiment_for(@name)[:metadata]
-      end
-
-      def load_metadata_from_redis
-        meta = redis.get(metadata_key)
-        JSON.parse(meta) unless meta.nil?
-      end
-
-      def load_alternatives_from_configuration
-        alts = Split.configuration.experiment_for(@name)[:alternatives]
-        raise ArgumentError, "Experiment configuration is missing :alternatives array" unless alts
-        if alts.is_a?(Hash)
-          alts.keys
-        else
-          alts.flatten
-        end
-      end
-
-      def load_alternatives_from_redis
-        alternatives = redis.lrange(@name, 0, -1)
-        alternatives.map do |alt|
-          alt = begin
-                  JSON.parse(alt)
-                rescue
-                  alt
-                end
-          Split::Alternative.new(alt, @name)
-        end
       end
 
     private

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -447,11 +447,11 @@ module Split
       end
 
       def experiment_configuration_has_changed?
-        existing_experiment = Experiment.find(@name)
+        stored_data = @redis_storage.load
 
-        existing_experiment.alternatives.map(&:to_s) != @alternatives.map(&:to_s) ||
-          existing_experiment.goals != @goals ||
-          existing_experiment.metadata != @metadata
+        stored_data[:alternatives].map(&:to_s) != @alternatives.map(&:to_s) ||
+          stored_data[:goals] != @goals ||
+          stored_data[:metadata] != @metadata
       end
 
       def goals_collection

--- a/lib/split/experiment_storage.rb
+++ b/lib/split/experiment_storage.rb
@@ -57,11 +57,9 @@ module Split
       def load_alternatives
         alts = Split.configuration.experiment_for(@name)[:alternatives]
         raise ArgumentError, "Experiment configuration is missing :alternatives array" unless alts
-        if alts.is_a?(Hash)
-          alts.keys
-        else
-          alts.flatten
-        end
+
+        alts = alts.keys if alts.is_a?(Hash)
+        alts.flatten
       end
 
       def load_metadata

--- a/lib/split/experiment_storage.rb
+++ b/lib/split/experiment_storage.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module Split
+  class ExperimentStorage
+    class BaseStorage
+      attr_accessor :name
+
+      def initialize(name)
+        @name = name
+      end
+
+      def load
+        @data ||= load!
+      end
+
+      def load!
+        experiment_config = load_experiment
+        alternatives = load_alternatives
+        metadata = load_metadata
+        goals = load_goals
+
+        {
+          resettable: experiment_config[:resettable],
+          algorithm: experiment_config[:algorithm],
+          alternatives: alternatives,
+          goals: goals,
+          metadata: metadata
+        }
+      end
+
+      def exists?
+        raise "implement"
+      end
+
+      def load_alternatives
+        raise "implement"
+      end
+
+      def load_metadata
+        raise "implement"
+      end
+
+      def load_goals
+        raise "implement"
+      end
+
+      def load_experiment
+        raise "implement"
+      end
+    end
+
+    class ConfigStorage < BaseStorage
+      def exists?
+        !!Split.configuration.experiment_for(@name)
+      end
+
+      def load_alternatives
+        alts = Split.configuration.experiment_for(@name)[:alternatives]
+        raise ArgumentError, "Experiment configuration is missing :alternatives array" unless alts
+        if alts.is_a?(Hash)
+          alts.keys
+        else
+          alts.flatten
+        end
+      end
+
+      def load_metadata
+        Split.configuration.experiment_for(@name)[:metadata]
+      end
+
+      def load_goals
+        Split::GoalsCollection.new(@name).load_from_configuration
+      end
+
+      def load_experiment
+        Split.configuration.experiment_for(@name)
+      end
+    end
+
+    class RedisStorage < BaseStorage
+      def exists?
+        redis.exists?(@name)
+      end
+
+      def load_alternatives
+        alternatives = redis.lrange(@name, 0, -1)
+        alternatives.map do |alt|
+          alt = begin
+                  JSON.parse(alt)
+                rescue
+                  alt
+                end
+          Split::Alternative.new(alt, @name)
+        end
+      end
+
+      def load_metadata
+        meta = redis.get(metadata_key)
+        JSON.parse(meta) unless meta.nil?
+      end
+
+      def load_goals
+        Split::GoalsCollection.new(@name).load_from_redis
+      end
+
+      def load_experiment
+        redis.hgetall(experiment_config_key).transform_keys(&:to_sym)
+      end
+
+      def experiment_config_key
+        "experiment_configurations/#{@name}"
+      end
+
+      def metadata_key
+        "#{name}:metadata"
+      end
+
+      private
+        def redis
+          Split.redis
+        end
+    end
+  end
+end

--- a/lib/split/persistence/redis_adapter.rb
+++ b/lib/split/persistence/redis_adapter.rb
@@ -27,7 +27,7 @@ module Split
       end
 
       def []=(field, value)
-        Split.redis.hset(redis_key, field, value.to_s)
+        Split.redis.hset(redis_key, field, value.to_s) if self[field] != value.to_s
         expire_seconds = self.class.config[:expire_seconds]
         Split.redis.expire(redis_key, expire_seconds) if expire_seconds
       end

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -16,7 +16,7 @@ module Split
     def cleanup_old_experiments!
       return if @cleaned_up
       keys_without_finished(user.keys).each do |key|
-        experiment = ExperimentCatalog.find key_without_version(key)
+        experiment = Experiment.new key_without_version(key)
         if experiment.nil? || experiment.has_winner? || experiment.start_time.nil?
           user.delete key
           user.delete Experiment.finished_key(key)

--- a/spec/experiment_storage_spec.rb
+++ b/spec/experiment_storage_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Split::ExperimentStorage do
+  let(:experiment) do
+    {
+      resettable: "false",
+      algorithm: "Split::Algorithms::WeightedSample",
+      alternatives: [ "foo", "bar" ],
+      goals: ["purchase", "refund"],
+      metadata: {
+        "foo" => { "text" => "Something bad" },
+        "bar" => { "text" => "Something good" }
+      }
+    }
+  end
+  before do
+    Split.configuration.experiments = {
+      my_exp: experiment
+    }
+  end
+
+  context "ConfigStorage" do
+    let(:config_store) { Split::ExperimentStorage::ConfigStorage.new("my_exp") }
+
+    it "loads an experiment from the configuration" do
+      stored_data = config_store.load
+      expect(stored_data).to match(experiment)
+    end
+
+    it "checks if an experiment exists on the configuration" do
+      expect(config_store.exists?).to be_truthy
+      expect(Split::ExperimentStorage::ConfigStorage.new("whatever").exists?).to be_falsy
+    end
+
+    it "memoizes data from the configuration by default" do
+      expect(config_store).to receive(:load!).once.and_call_original
+      config_store.load
+      config_store.load
+    end
+  end
+
+  context "from Redis" do
+    before { Split::ExperimentCatalog.find_or_create(:my_exp) }
+    let(:config_store) { Split::ExperimentStorage::RedisStorage.new("my_exp") }
+
+    it "loads an experiment from the configuration" do
+      stored_data = config_store.load
+      stored_data[:alternatives].map! { |alternative| alternative.name }
+      expect(stored_data).to match(experiment)
+    end
+
+    it "checks if an experiment exists on the configuration" do
+      expect(config_store.exists?).to be_truthy
+      expect(Split::ExperimentStorage::ConfigStorage.new("whatever").exists?).to be_falsy
+    end
+  end
+end


### PR DESCRIPTION
The main objetive of this refactor is to improve how split persists experiment/user data into Redis and centralize it on a single place. This can also allow other storage backends in the future, but it's not the main objetive ATM.

Split loads experiment data from hard coded configuration, data added directly ab_test calls and persists into Redis. Also, during ab_test calls, we also try to clean up after old experimentation data.

So, to make all that, there are spots that makes a lot of Redis calls, even for a single ab_test being called on a single page. 

I'm attempting the reduce the needless calls, and remove all the burden keeping it to a minimum. This should improve performance and reduce/remove the need of additional caching. 

The following changes already reduces the amount of redis calls by half. 

Things I want to address next:
- Move all experiment/goals/alternatives persistence logic to ExperimentStorage
- Move any extra redis calls from experiment data from Goals/ExperimentCatalog to the Storage
- There is no need to verify old experiments and user data and try clean them up on every single call ab_test call. 