### PR TITLE
docs: add cache invalidation warning for Redis Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,10 @@ Split.redis = split_config[Rails.env]
 
 ### Redis Caching (v4.0+)
 
-In some high-volume usage scenarios, Redis load can be incurred by repeated 
+> [!WARNING]
+> The caching mechanism has known issues in multi-process environments (e.g., Puma) and multi-server deployments with load balancers (typical production environments). Cache invalidation does not propagate across processes or servers, which can lead to inconsistent experiment data being served to users. See [#735](https://github.com/splitrb/split/issues/735) for details. Use with caution in production environments.
+
+In some high-volume usage scenarios, Redis load can be incurred by repeated
 fetches for fairly static data.  Enabling caching will reduce this load.
 
  ```ruby


### PR DESCRIPTION
## Description

This PR adds a warning to the Redis Caching section in the README to inform users about known cache invalidation issues in production environments.

## Problem

The current caching mechanism is not thread/process-safe. In multi-process environments (e.g., Puma) and multi-server deployments with load balancers, cache invalidation does not propagate across processes or servers. This can lead to inconsistent experiment data being served to users in production.

## Changes

- Added a WARNING callout to the "Redis Caching (v4.0+)" section in README.md
- Included reference to issue #735 for detailed information

## Related Issue

Relates to #735
