### PR TITLE
 ci: use bundler-cache in setup-ruby and fix RuboCop configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: Install dependencies
-        run: |
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Display Ruby version
         run: ruby -v

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,11 @@
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   TargetRubyVersion: 2.5
   DisabledByDefault: true
   SuggestExtensions: false
-  Exclude:
-    - 'gemfiles/**/*'
-    - 'vendor/**/*'
 
 Style/AndOr:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   SuggestExtensions: false
   Exclude:
     - 'gemfiles/**/*'
+    - 'vendor/**/*'
 
 Style/AndOr:
   Enabled: true


### PR DESCRIPTION
This PR fixes [CI failures](https://github.com/splitrb/split/actions/runs/22017932224/job/63622378441#step:5:115) currently occurring on the main branch.

## Background

The manual `bundle install` step was causing CI failures with the following error:

```
Bundler cannot reinstall erb-6.0.1 because there's a previous installation of it
at /opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/gems/4.0.0/gems/erb-6.0.1 that
is unsafe to remove.
The parent of
/opt/hostedtoolcache/Ruby/4.0.1/x64/lib/ruby/gems/4.0.0/gems/erb-6.0.1 is
world-writable and does not have the sticky bit set, making it insecure to
remove due to potential vulnerabilities.
```

This issue is related to stricter security checks introduced in [RubyGems/Bundler 4.0.0](https://blog.rubygems.org/2025/12/03/4.0.0-released.html) combined with incorrect directory permissions in GitHub Actions hosted toolcache. The same issue has been reported in
  [ruby/rubygems#7983](https://github.com/ruby/rubygems/issues/7983) and [ruby/setup-ruby#624](https://github.com/ruby/setup-ruby/issues/624).

## Changes

1. **Use `bundler-cache` in `ruby/setup-ruby` action**
   - Replaced manual `bundle install` with `bundler-cache: true` option
   - This is the [recommended solution](https://github.com/ruby/setup-ruby#caching-bundle-install-automatically) that avoids permission issues and improves caching
   - Gems are now installed under `vendor/bundle` directory

2. **Configure RuboCop to inherit default exclusions**
   - Added `inherit_mode` configuration to merge `Exclude` patterns with RuboCop defaults
   - RuboCop's default configuration excludes common directories like `vendor/**/*`, but when a local `.rubocop.yml` defines `AllCops.Exclude`, it overrides the defaults instead of merging
   - By setting `inherit_mode: { merge: [Exclude] }`, we explicitly inherit the default exclusions while allowing custom exclusions
   - This ensures `vendor/bundle` (where gems are now installed) is properly excluded from linting


Sources:
- https://blog.rubygems.org/2025/12/03/4.0.0-released.html
- https://github.com/ruby/rubygems/issues/7983
- https://github.com/ruby/setup-ruby/issues/624

