### PR TITLE
Prefetch trial state in a single Redis roundtrip

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -176,17 +176,27 @@ module Split
     end
 
     def start_time
-      @start_time ||= Split.cache(:experiment_start_times, @name) do
-        t = redis.hget(:experiment_start_times, @name)
-        if t
-          # Check if stored time is an integer
-          if t =~ /^[-+]?[0-9]+$/
-            Time.at(t.to_i)
-          else
-            Time.parse(t)
-          end
-        end
+      return @start_time if defined?(@start_time)
+
+      @start_time = Split.cache(:experiment_start_times, @name) do
+        parse_start_time(redis.hget(:experiment_start_times, @name))
       end
+    end
+
+    def prefetch_trial_state!
+      winner_name, raw_start_time, raw_version, raw_cohorting =
+        redis.pipelined do |pipe|
+          pipe.hget(:experiment_winner, name)
+          pipe.hget(:experiment_start_times, @name)
+          pipe.get("#{name}:version")
+          pipe.hget(experiment_config_key, :cohorting)
+        end
+
+      @has_winner = !winner_name.nil?
+      @start_time = parse_start_time(raw_start_time)
+      @version = raw_version.to_i
+      @cohorting_disabled = raw_cohorting.nil? ? false : raw_cohorting.downcase == "true"
+      self
     end
 
     def next_alternative
@@ -402,10 +412,9 @@ module Split
     end
 
     def cohorting_disabled?
-      @cohorting_disabled ||= begin
-        value = redis.hget(experiment_config_key, :cohorting)
-        value.nil? ? false : value.downcase == "true"
-      end
+      return @cohorting_disabled if defined?(@cohorting_disabled)
+      value = redis.hget(experiment_config_key, :cohorting)
+      @cohorting_disabled = value.nil? ? false : value.downcase == "true"
     end
 
     def disable_cohorting
@@ -424,6 +433,17 @@ module Split
       end
 
     private
+      def parse_start_time(t)
+        return if t.nil?
+
+        # Check if stored time is an integer
+        if t =~ /^[-+]?[0-9]+$/
+          Time.at(t.to_i)
+        else
+          Time.parse(t)
+        end
+      end
+
       def redis
         Split.redis
       end

--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -56,6 +56,8 @@ module Split
       # Only run the process once
       return alternative if @alternative_chosen
 
+      @experiment.prefetch_trial_state!
+
       new_participant = @user[@experiment.key].nil?
       if override_is_alternative?
         self.alternative = @options[:override]


### PR DESCRIPTION
This is part of an effort to reduce the burden of N roundtrips and drop the need of a cache impl.  

Trial#choose! reads an experiment's winner, start time, version, and cohorting flag on every ab_test. This batches all four into one pipelined roundtrip.

No change in behavior, just making all calls at the same time. 4 redis calls are reduced to a single one here. 