### PR TITLE
Metric lookup short circuit to avoid an extra redis call

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,11 +636,15 @@ the experiment name:
 ab_finished(:my_metric)
 ```
 
-You can also create a new metric by instantiating and saving a new Metric object.
+You can also create a new metric by instantiating and saving a new Metric
+object. A metric groups one or more experiments (`Split::Experiment` objects)
+under a name and is persisted to Redis:
 
 ```ruby
-Split::Metric.new(:my_metric)
-Split::Metric.save
+signup   = Split::ExperimentCatalog.find_or_create("signup_form", "control", "blue")
+checkout = Split::ExperimentCatalog.find_or_create("checkout_flow", "control", "one_page")
+
+Split::Metric.new(name: :conversion, experiments: [signup, checkout]).save
 ```
 
 #### Goals

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -56,7 +56,7 @@ module Split
 
     def active_experiments
       experiments_by_key = keys_without_finished(user.keys).each_with_object({}) do |key, memo|
-        memo[key] = Metric.possible_experiments(key_without_version(key))
+        memo[key] = experiments_for(key_without_version(key))
       end
 
       names = experiments_by_key.values.flatten.map(&:name).uniq
@@ -94,6 +94,20 @@ module Split
 
       def key_without_version(key)
         key.split(/\:\d(?!\:)/)[0]
+      end
+
+      def experiments_for(name)
+        if metrics_defined?
+          Metric.possible_experiments(name)
+        else
+          Array(Experiment.find(name))
+        end
+      end
+
+      def metrics_defined?
+        return @metrics_defined if defined?(@metrics_defined)
+        @metrics_defined =
+          Split.configuration.metrics.any? || Split.redis.exists?(:metrics)
       end
   end
 end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -137,6 +137,18 @@ describe Split::User do
       expect(Split.redis).to receive(:hmget).with(:experiment_winner, any_args).once.and_call_original
       @subject.active_experiments
     end
+
+    it "resolves experiments directly, without per-key metric lookups, when no metrics are defined" do
+      expect(Split::Metric).not_to receive(:possible_experiments)
+      expect(@subject.active_experiments).to eq("active" => "red")
+    end
+
+    it "still honors a metric persisted only in Redis" do
+      Split::Metric.new(name: :conversion, experiments: [Split::ExperimentCatalog.find("active")]).save
+
+      expect(Split::Metric).to receive(:possible_experiments).at_least(:once).and_call_original
+      expect(@subject.active_experiments).to eq("active" => "red")
+    end
   end
 
   context "allows user to be loaded from adapter" do


### PR DESCRIPTION
Fix the broken "create a metric via code" README example. Replaced with a working example that is used on the specs.

Skip per-key metric lookups in active_experiments when no metrics exist. I don't think metrics is widely used, and considering just dropping it. This scenario tries to mitigate N HGET calls and calling a single exists. 